### PR TITLE
9 toggle component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sd-material-ui",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sd-material-ui",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "StratoDem Analytics Dash implementation of material-ui components",
   "main": "lib/index.js",
   "repository": {

--- a/sd_material_ui/metadata.json
+++ b/sd_material_ui/metadata.json
@@ -1546,5 +1546,307 @@
         "description": ""
       }
     }
+  },
+  "src/components/SDToggle.react.js": {
+    "description": "",
+    "displayName": "SDToggle",
+    "methods": [
+      {
+        "name": "handleToggle",
+        "docblock": null,
+        "modifiers": [],
+        "params": [
+          {
+            "name": "toggled",
+            "type": {
+              "name": "boolean"
+            }
+          }
+        ],
+        "returns": null
+      }
+    ],
+    "props": {
+      "disabled": {
+        "type": {
+          "name": "bool"
+        },
+        "required": false,
+        "description": "Will disable the toggle if true.",
+        "flowType": {
+          "name": "boolean"
+        },
+        "defaultValue": {
+          "value": "false",
+          "computed": false
+        }
+      },
+      "elementStyle": {
+        "type": {
+          "name": "objectOf",
+          "value": {
+            "name": "any"
+          }
+        },
+        "required": false,
+        "description": "Overrides the inline-styles of the Toggle element.",
+        "flowType": {
+          "name": "Object"
+        },
+        "defaultValue": {
+          "value": "{}",
+          "computed": false
+        }
+      },
+      "fireEvent": {
+        "type": {
+          "name": "func"
+        },
+        "required": false,
+        "description": "A callback for firing events to dash.",
+        "flowType": {
+          "name": "signature",
+          "type": "function",
+          "raw": "() => void",
+          "signature": {
+            "arguments": [],
+            "return": {
+              "name": "void"
+            }
+          }
+        },
+        "defaultValue": {
+          "value": "() => {}",
+          "computed": false
+        }
+      },
+      "iconStyle": {
+        "type": {
+          "name": "objectOf",
+          "value": {
+            "name": "any"
+          }
+        },
+        "required": false,
+        "description": "Overrides the inline-styles of the Icon element.",
+        "flowType": {
+          "name": "Object"
+        },
+        "defaultValue": {
+          "value": "{}",
+          "computed": false
+        }
+      },
+      "id": {
+        "type": {
+          "name": "string"
+        },
+        "required": true,
+        "description": "The element's ID",
+        "flowType": {
+          "name": "string"
+        }
+      },
+      "inputStyle": {
+        "type": {
+          "name": "objectOf",
+          "value": {
+            "name": "any"
+          }
+        },
+        "required": false,
+        "description": "Overrides the inline-styles of the input element.",
+        "flowType": {
+          "name": "Object"
+        },
+        "defaultValue": {
+          "value": "{}",
+          "computed": false
+        }
+      },
+      "label": {
+        "type": {
+          "name": "node"
+        },
+        "required": false,
+        "description": "Label for toggle.",
+        "flowType": {
+          "name": "Node"
+        },
+        "defaultValue": {
+          "value": "''",
+          "computed": false
+        }
+      },
+      "labelPosition": {
+        "type": {
+          "name": "string"
+        },
+        "required": false,
+        "description": "Where the label will be placed next to the toggle.",
+        "flowType": {
+          "name": "string"
+        },
+        "defaultValue": {
+          "value": "'left'",
+          "computed": false
+        }
+      },
+      "labelStyle": {
+        "type": {
+          "name": "objectOf",
+          "value": {
+            "name": "any"
+          }
+        },
+        "required": false,
+        "description": "Overrides the inline-styles of the Toggle element label.",
+        "flowType": {
+          "name": "Object"
+        },
+        "defaultValue": {
+          "value": "{}",
+          "computed": false
+        }
+      },
+      "rippleStyle": {
+        "type": {
+          "name": "objectOf",
+          "value": {
+            "name": "any"
+          }
+        },
+        "required": false,
+        "description": "Override style of ripple.",
+        "flowType": {
+          "name": "Object"
+        },
+        "defaultValue": {
+          "value": "{}",
+          "computed": false
+        }
+      },
+      "setProps": {
+        "type": {
+          "name": "func"
+        },
+        "required": false,
+        "description": "Dash callback to update props on the server",
+        "flowType": {
+          "name": "signature",
+          "type": "function",
+          "raw": "() => void",
+          "signature": {
+            "arguments": [],
+            "return": {
+              "name": "void"
+            }
+          }
+        },
+        "defaultValue": {
+          "value": "() => {}",
+          "computed": false
+        }
+      },
+      "style": {
+        "type": {
+          "name": "objectOf",
+          "value": {
+            "name": "any"
+          }
+        },
+        "required": false,
+        "description": "Override the inline-styles of the root element.",
+        "flowType": {
+          "name": "Object"
+        },
+        "defaultValue": {
+          "value": "{}",
+          "computed": false
+        }
+      },
+      "thumbStyle": {
+        "type": {
+          "name": "objectOf",
+          "value": {
+            "name": "any"
+          }
+        },
+        "required": false,
+        "description": "Override style for thumb.",
+        "flowType": {
+          "name": "Object"
+        },
+        "defaultValue": {
+          "value": "{}",
+          "computed": false
+        }
+      },
+      "thumbSwitchedStyle": {
+        "type": {
+          "name": "objectOf",
+          "value": {
+            "name": "any"
+          }
+        },
+        "required": false,
+        "description": "Override the inline styles for thumb when the toggle switch is toggled on.",
+        "flowType": {
+          "name": "Object"
+        },
+        "defaultValue": {
+          "value": "{}",
+          "computed": false
+        }
+      },
+      "toggled": {
+        "type": {
+          "name": "bool"
+        },
+        "required": false,
+        "description": "Toggled if set to true.",
+        "flowType": {
+          "name": "boolean"
+        },
+        "defaultValue": {
+          "value": "false",
+          "computed": false
+        }
+      },
+      "trackStyle": {
+        "type": {
+          "name": "objectOf",
+          "value": {
+            "name": "any"
+          }
+        },
+        "required": false,
+        "description": "Override style for track.",
+        "flowType": {
+          "name": "Object"
+        },
+        "defaultValue": {
+          "value": "{}",
+          "computed": false
+        }
+      },
+      "trackSwitchedStyle": {
+        "type": {
+          "name": "objectOf",
+          "value": {
+            "name": "any"
+          }
+        },
+        "required": false,
+        "description": "Override the inline styles for track when the toggle switch is toggled on.",
+        "flowType": {
+          "name": "Object"
+        },
+        "defaultValue": {
+          "value": "{}",
+          "computed": false
+        }
+      }
+    }
   }
 }

--- a/sd_material_ui/version.py
+++ b/sd_material_ui/version.py
@@ -9,4 +9,4 @@ Notes :
 December 28, 2017
 """
 
-__version__ = '1.4.0'
+__version__ = '1.5.0'

--- a/src/components/SDCheckbox.react.js
+++ b/src/components/SDCheckbox.react.js
@@ -150,6 +150,8 @@ export default class SDCheckbox extends Component<Props, State> {
               label={label}
               labelPosition={labelPosition}
               labelStyle={labelStyle}
+              onCheck={(event: object, isInputChecked: boolean) =>
+                this.setState({checked: isInputChecked})}
               style={style}
             />
           </MuiThemeProvider>

--- a/src/components/SDToggle.react.js
+++ b/src/components/SDToggle.react.js
@@ -160,8 +160,6 @@ export default class SDToggle extends Component<Props, State> {
     if (this.props.fireEvent) this.props.fireEvent({event: 'click'});
   };
 
-  // TODO increment version number
-
   render() {
     const { disabled, elementStyle, iconStyle, id, inputStyle, label, labelPosition,
       labelStyle, rippleStyle, style, thumbStyle, thumbSwitchedStyle,

--- a/src/components/SDToggle.react.js
+++ b/src/components/SDToggle.react.js
@@ -1,0 +1,204 @@
+// @flow
+
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+import Toggle from 'material-ui/Toggle';
+import lightBaseTheme from 'material-ui/styles/baseThemes/lightBaseTheme';
+import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
+import getMuiTheme from 'material-ui/styles/getMuiTheme';
+
+type Props = {
+  disabled?: boolean,
+  elementStyle?: Object,
+  fireEvent?: () => void,
+  iconStyle?: Object,
+  id: string,
+  inputStyle?: Object,
+  label?: Node,
+  labelPosition?: string,
+  labelStyle?: Object,
+  rippleStyle?: Object,
+  setProps?: () => void,
+  style?: Object,
+  thumbStyle?: Object,
+  thumbSwitchedStyle?: Object,
+  toggled?: boolean,
+  trackStyle?: Object,
+  trackSwitchedStyle?: Object,
+};
+
+const propTypes = {
+  /**
+   * Will disable the toggle if true.
+   */
+  disabled: PropTypes.bool,
+
+  /**
+   * Overrides the inline-styles of the Toggle element.
+   */
+  elementStyle: PropTypes.objectOf(PropTypes.any),
+
+  /**
+   * A callback for firing events to dash.
+   */
+  fireEvent: PropTypes.func,
+
+  /**
+   * 	Overrides the inline-styles of the Icon element.
+   */
+  iconStyle: PropTypes.objectOf(PropTypes.any),
+
+  /**
+   * The element's ID
+   */
+  id: PropTypes.string,
+
+  /**
+   * Overrides the inline-styles of the input element.
+   */
+  inputStyle: PropTypes.objectOf(PropTypes.any),
+
+  /**
+   * Label for toggle.
+   */
+  label: PropTypes.node,
+
+  /**
+   * Where the label will be placed next to the toggle.
+   */
+  labelPosition: PropTypes.string,
+
+  /**
+   * 	Overrides the inline-styles of the Toggle element label.
+   */
+  labelStyle: PropTypes.objectOf(PropTypes.any),
+
+  /**
+   * Override style of ripple.
+   */
+  rippleStyle: PropTypes.objectOf(PropTypes.any),
+
+  /**
+   * Dash callback to update props on the server
+   */
+  setProps: PropTypes.func,
+
+  /**
+   * Override the inline-styles of the root element.
+   */
+  style: PropTypes.objectOf(PropTypes.any),
+
+  /**
+   * Override style for thumb.
+   */
+  thumbStyle: PropTypes.objectOf(PropTypes.any),
+
+  /**
+   * Override the inline styles for thumb when the toggle switch is toggled on.
+   */
+  thumbSwitchedStyle: PropTypes.objectOf(PropTypes.any),
+
+  /**
+   * 	Toggled if set to true.
+   */
+  toggled: PropTypes.bool,
+
+  /**
+   * Override style for track.
+   */
+  trackStyle: PropTypes.objectOf(PropTypes.any),
+
+  /**
+   * Override the inline styles for track when the toggle switch is toggled on.
+   */
+  trackSwitchedStyle: PropTypes.objectOf(PropTypes.any),
+};
+
+const defaultProps = {
+  disabled: false,
+  elementStyle: {},
+  fireEvent: () => {},
+  iconStyle: {},
+  inputStyle: {},
+  label: '',
+  labelPosition: 'left',
+  labelStyle: {},
+  rippleStyle: {},
+  setProps: () => {},
+  style: {},
+  thumbStyle: {},
+  thumbSwitchedStyle: {},
+  toggled: false,
+  trackStyle: {},
+  trackSwitchedStyle: {},
+};
+
+export default class SDToggle extends React.Component<Props> {
+  constructor(props.Props) {
+    super(props);
+  }
+
+  handleToggle() {
+    if (this.props.setProps) this.props.setProps({toggled: this.props.});
+    if (this.props.fireEvent) this.props.fireEvent({event: 'click'});
+}
+
+  // TODO increment version number
+
+  render() {
+    const { disabled, elementStyle, iconStyle, inputStyle, label, labelPosition,
+      labelStyle, rippleStyle, style, thumbStyle, thumbSwitchedStyle, toggled,
+      trackStyle, trackSwitchedStyle } = this.props;
+
+    if (this.props.fireEvent || this.props.setProps) {
+      return (
+        <div id={id}>
+          <MuiThemeProvider muiTheme={getMuiTheme(lightBaseTheme)}>
+            <Toggle
+              disabled={disabled}
+              elementStyle={elementStyle}
+              iconStyle={iconStyle}
+              inputStyle={inputStyle}
+              label={label}
+              labelposition={labelPosition}
+              labelStyle={labelStyle}
+              onToggle=(event: object, isInputChecked: boolean) =>
+                { this.handleToggle(isInputChecked) }
+              rippleStyle={rippleStyle}
+              style={style}
+              thumbStyle={thumbStyle}
+              thumbSwitchedStyle={thumbSwitchedStyle}
+              toggled={toggled}
+              trackStyle={trackStyle}
+              trackSwitchedStyle={trackSwitchedStyle}
+            />
+          </MuiThemeProvider>
+        </div>
+      )
+    } else {
+      return (
+        <div id={id}>
+          <MuiThemeProvider muiTheme={getMuiTheme(lightBaseTheme)}>
+            <Toggle
+              disabled={disabled}
+              elementStyle={elementStyle}
+              iconStyle={iconStyle}
+              inputStyle={inputStyle}
+              label={label}
+              labelposition={labelPosition}
+              labelStyle={labelStyle}
+              rippleStyle={rippleStyle}
+              style={style}
+              thumbStyle={thumbStyle}
+              thumbSwitchedStyle={thumbSwitchedStyle}
+              toggled={toggled}
+              trackStyle={trackStyle}
+              trackSwitchedStyle={trackSwitchedStyle}
+            />
+          </MuiThemeProvider>
+        </div>
+      )
+    }
+  }
+}

--- a/src/components/SDToggle.react.js
+++ b/src/components/SDToggle.react.js
@@ -138,10 +138,10 @@ const defaultProps = {
   trackSwitchedStyle: {},
 };
 
-export default class SDToggle extends React.Component<Props, State> {
+export default class SDToggle extends Component<Props, State> {
   constructor(props: Props) {
     super(props);
-    this.state = {toggled: props.toggled};
+    this.state = {switched: props.toggled};
   }
 
   componentWillReceiveProps(nextProps: Props): void {
@@ -155,7 +155,7 @@ export default class SDToggle extends React.Component<Props, State> {
     if (typeof setProps === 'function')
       setProps({toggled});
 
-    this.setState({toggled});
+    this.setState({switched: toggled});
 
     if (this.props.fireEvent) this.props.fireEvent({event: 'click'});
   };
@@ -208,7 +208,7 @@ export default class SDToggle extends React.Component<Props, State> {
               style={style}
               thumbStyle={thumbStyle}
               thumbSwitchedStyle={thumbSwitchedStyle}
-              toggled={this.state.toggled}
+              toggled={this.state.switched}
               trackStyle={trackStyle}
               trackSwitchedStyle={trackSwitchedStyle}
             />

--- a/src/components/SDToggle.react.js
+++ b/src/components/SDToggle.react.js
@@ -45,14 +45,14 @@ const propTypes = {
   fireEvent: PropTypes.func,
 
   /**
-   * 	Overrides the inline-styles of the Icon element.
+   * Overrides the inline-styles of the Icon element.
    */
   iconStyle: PropTypes.objectOf(PropTypes.any),
 
   /**
    * The element's ID
    */
-  id: PropTypes.string,
+  id: PropTypes.string.isRequired,
 
   /**
    * Overrides the inline-styles of the input element.
@@ -70,7 +70,7 @@ const propTypes = {
   labelPosition: PropTypes.string,
 
   /**
-   * 	Overrides the inline-styles of the Toggle element label.
+   * Overrides the inline-styles of the Toggle element label.
    */
   labelStyle: PropTypes.objectOf(PropTypes.any),
 
@@ -100,7 +100,7 @@ const propTypes = {
   thumbSwitchedStyle: PropTypes.objectOf(PropTypes.any),
 
   /**
-   * 	Toggled if set to true.
+   * Toggled if set to true.
    */
   toggled: PropTypes.bool,
 
@@ -113,6 +113,10 @@ const propTypes = {
    * Override the inline styles for track when the toggle switch is toggled on.
    */
   trackSwitchedStyle: PropTypes.objectOf(PropTypes.any),
+};
+
+type State = {
+  switched: boolean,
 };
 
 const defaultProps = {
@@ -134,21 +138,33 @@ const defaultProps = {
   trackSwitchedStyle: {},
 };
 
-export default class SDToggle extends React.Component<Props> {
-  constructor(props.Props) {
+export default class SDToggle extends React.Component<Props, State> {
+  constructor(props: Props) {
     super(props);
+    this.state = {toggled: props.toggled};
   }
 
-  handleToggle() {
-    if (this.props.setProps) this.props.setProps({toggled: this.props.});
+  componentWillReceiveProps(nextProps: Props): void {
+    if (nextProps.toggled !== null && nextProps.toggled !== this.props.toggled)
+      this.handleToggle(nextProps.toggled);
+  }
+
+  handleToggle = (toggled: boolean) => {
+    const { setProps } = this.props;
+
+    if (typeof setProps === 'function')
+      setProps({toggled});
+
+    this.setState({toggled});
+
     if (this.props.fireEvent) this.props.fireEvent({event: 'click'});
-}
+  };
 
   // TODO increment version number
 
   render() {
-    const { disabled, elementStyle, iconStyle, inputStyle, label, labelPosition,
-      labelStyle, rippleStyle, style, thumbStyle, thumbSwitchedStyle, toggled,
+    const { disabled, elementStyle, iconStyle, id, inputStyle, label, labelPosition,
+      labelStyle, rippleStyle, style, thumbStyle, thumbSwitchedStyle,
       trackStyle, trackSwitchedStyle } = this.props;
 
     if (this.props.fireEvent || this.props.setProps) {
@@ -163,19 +179,19 @@ export default class SDToggle extends React.Component<Props> {
               label={label}
               labelposition={labelPosition}
               labelStyle={labelStyle}
-              onToggle=(event: object, isInputChecked: boolean) =>
-                { this.handleToggle(isInputChecked) }
+              onToggle={(event: object, isInputChecked: boolean) =>
+                this.handleToggle(isInputChecked)}
               rippleStyle={rippleStyle}
               style={style}
               thumbStyle={thumbStyle}
               thumbSwitchedStyle={thumbSwitchedStyle}
-              toggled={toggled}
+              toggled={this.state.switched}
               trackStyle={trackStyle}
               trackSwitchedStyle={trackSwitchedStyle}
             />
           </MuiThemeProvider>
         </div>
-      )
+      );
     } else {
       return (
         <div id={id}>
@@ -192,13 +208,16 @@ export default class SDToggle extends React.Component<Props> {
               style={style}
               thumbStyle={thumbStyle}
               thumbSwitchedStyle={thumbSwitchedStyle}
-              toggled={toggled}
+              toggled={this.state.toggled}
               trackStyle={trackStyle}
               trackSwitchedStyle={trackSwitchedStyle}
             />
           </MuiThemeProvider>
         </div>
-      )
+      );
     }
   }
 }
+
+SDToggle.propTypes = propTypes;
+SDToggle.defaultProps = defaultProps;

--- a/src/components/SDToggle.react.js
+++ b/src/components/SDToggle.react.js
@@ -175,7 +175,7 @@ export default class SDToggle extends Component<Props, State> {
               iconStyle={iconStyle}
               inputStyle={inputStyle}
               label={label}
-              labelposition={labelPosition}
+              labelPosition={labelPosition}
               labelStyle={labelStyle}
               onToggle={(event: object, isInputChecked: boolean) =>
                 this.handleToggle(isInputChecked)}
@@ -202,6 +202,8 @@ export default class SDToggle extends Component<Props, State> {
               label={label}
               labelposition={labelPosition}
               labelStyle={labelStyle}
+              onToggle={(event: object, isInputChecked: boolean) =>
+                this.setState({switched: isInputChecked})}
               rippleStyle={rippleStyle}
               style={style}
               thumbStyle={thumbStyle}

--- a/src/components/__tests__/SDCheckbox.test.js
+++ b/src/components/__tests__/SDCheckbox.test.js
@@ -1,6 +1,8 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import ReactTestUtils from 'react-dom/test-utils';
+import { mount, shallow } from 'enzyme';
 import SDCheckbox from '../SDCheckbox.react';
+
 
 describe('SDCheckbox', () => {
   it('renders', () => {
@@ -12,7 +14,7 @@ describe('SDCheckbox', () => {
     expect(component).toBe.ok;
   });
 
-  it('updates based on clicks', () => {
+  it('updates props correctly', () => {
     const component = shallow(
       <SDCheckbox id='test-id' />);
 
@@ -21,5 +23,23 @@ describe('SDCheckbox', () => {
     expect(component.state('checked')).toEqual(true);
     component.setProps({checked: false});
     expect(component.state('checked')).toEqual(false);
+  });
+
+  it('handles click events', () => {
+    const component = mount(
+      <SDCheckbox id='test-id' />);
+
+    expect(component.state('checked')).toEqual(false);
+    component.find('Checkbox').props().onCheck({}, true);
+    expect(component.state('checked')).toEqual(true);
+  });
+
+  it('sets state even without setProps/fireEvent', () => {
+    const component = shallow(
+      <SDCheckbox id='test-id' setProps={null} fireEvent={null} />);
+
+    expect(component.state('checked')).toEqual(false);
+    component.find('Checkbox').props().onCheck({}, true);
+    expect(component.state('checked')).toEqual(true);
   });
 });

--- a/src/components/__tests__/SDRaisedButton.test.js
+++ b/src/components/__tests__/SDRaisedButton.test.js
@@ -33,16 +33,6 @@ describe('SDRaisedButton', () => {
     expect(component.contains(<div className="myDiv" />)).toEqual(true);
   });
 
-  // it('uses the styles provided', () => {
-  //   const component = shallow(
-  //     <SDRaisedButton id='test-id' backgroundColor='black' fullWidth={true}>
-  //       children=<div />
-  //     </SDRaisedButton>);
-  //
-  //   expect(component.find('RaisedButton').props().backgroundColor).toEqual('black');
-  //   expect(component.find('RaisedButton').props().fullWidth).toEqual(true);
-  // });
-
   it('increments n_clicks', () => {
     const mockProps = jest.fn();
     const component = shallow(

--- a/src/components/__tests__/SDToggle.test.js
+++ b/src/components/__tests__/SDToggle.test.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import SDToggle from '../SDToggle.react';
+
+describe('SDToggle', () => {
+  it('renders', () => {
+    const component = shallow(
+      <SDToggle id='test-id' />
+    );
+
+    expect(component.props().id).toEqual('test-id');
+    expect(component).toBe.ok;
+  });
+
+  it('updates based on clicks', () => {
+    const component = shallow(
+      <SDToggle id='test-id' />);
+
+    expect(component.state('switched')).toEqual(false);
+    component.setProps({toggled: true});
+    expect(component.state('switched')).toEqual(true);
+    component.setProps({toggled: false});
+    expect(component.state('switched')).toEqual(false);
+  });
+});

--- a/src/components/__tests__/SDToggle.test.js
+++ b/src/components/__tests__/SDToggle.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import SDToggle from '../SDToggle.react';
 
 describe('SDToggle', () => {
@@ -12,7 +12,7 @@ describe('SDToggle', () => {
     expect(component).toBe.ok;
   });
 
-  it('updates based on clicks', () => {
+  it('updates props correctly', () => {
     const component = shallow(
       <SDToggle id='test-id' />);
 
@@ -21,5 +21,23 @@ describe('SDToggle', () => {
     expect(component.state('switched')).toEqual(true);
     component.setProps({toggled: false});
     expect(component.state('switched')).toEqual(false);
+  });
+
+  it('handles click events', () => {
+    const component = mount(
+      <SDToggle id='test-id' />);
+
+    expect(component.state('switched')).toEqual(false);
+    component.find('Toggle').props().onToggle({}, true);
+    expect(component.state('switched')).toEqual(true);
+  });
+
+  it('sets state even without setProps/fireEvent', () => {
+    const component = shallow(
+      <SDToggle id='test-id' setProps={null} fireEvent={null} />);
+
+    expect(component.state('switched')).toEqual(false);
+    component.find('Toggle').props().onToggle({}, true);
+    expect(component.state('switched')).toEqual(true);
   });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import SDDialog from './components/SDDialog.react';
 import SDDrawer from './components/SDDrawer.react';
 import SDFlatButton from './components/SDFlatButton.react';
 import SDRaisedButton from './components/SDRaisedButton.react';
+import SDToggle from './components/SDToggle.react';
 
 export {
   BottomNavigation,
@@ -12,4 +13,5 @@ export {
   SDDrawer,
   SDFlatButton,
   SDRaisedButton,
+  SDToggle,
 };

--- a/usage.py
+++ b/usage.py
@@ -6,6 +6,8 @@ app = dash.Dash('')
 
 app.scripts.config.serve_locally = True
 
+spacer = html.Div(children=[], style=dict(height=20))
+
 app.layout = html.Div([
 
     # Test BottomNavigation
@@ -19,6 +21,8 @@ app.layout = html.Div([
         ]),
     html.Div(id='output'),
 
+    spacer,
+
     # Test SDDialog (modal)
     sd_material_ui.SDDialog(
         html.Div(children=[
@@ -30,6 +34,8 @@ app.layout = html.Div([
         open=False),
     html.Div(id='input2', children=[html.P('Share the page (modal)')]),
 
+    spacer,
+
     # Test SDDialog (non-modal)
     sd_material_ui.SDDialog(
         html.Div(children=[
@@ -40,17 +46,23 @@ app.layout = html.Div([
         open=False),
     html.Div(id='non-modal-input', children=[html.P('Share the page (non-modal)')]),
 
+    spacer,
+
     # Test SDRaisedButton
     html.Div(children=[
         html.P(id='output4', children=['n_clicks value: '])
     ]),
     sd_material_ui.SDRaisedButton(id='input4', label='Click me'),
 
+    spacer,
+
     # Test SDFlatButton
     html.Div(children=[
         html.P(id='output5', children=['n_clicks value: '])
     ]),
     sd_material_ui.SDFlatButton(id='input5', label='Click me', backgroundColor='orange'),
+
+    spacer,
 
     # Test for SDDrawer (docked, secondary)
     sd_material_ui.SDDrawer(id='output6', docked=True, openSecondary=True,
@@ -59,6 +71,8 @@ app.layout = html.Div([
         html.P(children='Open or close the drawer (docked)')
     ]),
 
+    spacer,
+
     # Test for SDDrawer (not docked)
     sd_material_ui.SDDrawer(id='output7', docked=False, open=False, children=[
         html.P(id='close-input7', children='Drawer item')]),
@@ -66,17 +80,23 @@ app.layout = html.Div([
         html.P(children='Open or close the drawer (not docked)')
     ]),
 
+    spacer,
+
     # Test for SDCheckbox
     html.Div(id='output8', children=[
         html.P('Box is not checked')
     ]),
     sd_material_ui.SDCheckbox(id='input8', label='Check to change the text above.'),
 
+    spacer,
+
     # Test for SDToggle
-    sd_material_ui.SDToggle(id='input9', label='Johnny?'),
-    html.Div(id='output9', children=[
-        html.P('Flame off')
-    ]),
+    html.Div(children=[
+        sd_material_ui.SDToggle(id='input9', label='Johnny?'),
+        html.Div(id='output9', children=[
+            html.P('Flame off')
+        ]),
+     ], style=dict(width=150)),
 ])
 
 

--- a/usage.py
+++ b/usage.py
@@ -71,6 +71,12 @@ app.layout = html.Div([
         html.P('Box is not checked')
     ]),
     sd_material_ui.SDCheckbox(id='input8', label='Check to change the text above.'),
+
+    # Test for SDToggle
+    sd_material_ui.SDToggle(id='input9', label='Johnny?'),
+    html.Div(id='output9', children=[
+        html.P('Flame off')
+    ]),
 ])
 
 
@@ -167,6 +173,17 @@ def use_clickbox(checkbox):
         return ['Box is checked']
     else:
         return ['Box is unchecked']
+
+
+# Callback for SDToggle
+@app.callback(
+    dash.dependencies.Output('output9', 'children'),
+    [dash.dependencies.Input('input9', 'toggled')])
+def use_toggle(switch):
+    if switch:
+        return ['Flame on!']
+    else:
+        return ['Flame off']
 
 
 if __name__ == '__main__':

--- a/usage.py
+++ b/usage.py
@@ -72,8 +72,6 @@ app.layout = html.Div([
     ]),
     sd_material_ui.SDCheckbox(id='input8', label='Check to change the text above.'),
 
-    # TODO why isn't SDToggle found (error on page load)?
-
     # Test for SDToggle
     sd_material_ui.SDToggle(id='input9', label='Johnny?'),
     html.Div(id='output9', children=[

--- a/usage.py
+++ b/usage.py
@@ -72,6 +72,8 @@ app.layout = html.Div([
     ]),
     sd_material_ui.SDCheckbox(id='input8', label='Check to change the text above.'),
 
+    # TODO why isn't SDToggle found (error on page load)?
+
     # Test for SDToggle
     sd_material_ui.SDToggle(id='input9', label='Johnny?'),
     html.Div(id='output9', children=[


### PR DESCRIPTION
## Description
Adds a Dash-compatible version of material-ui's toggle switch.

closes #9 

## How has this been tested?
Manual and automated tests for this component are included, and all have passed.