### PR TITLE
32 change value prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.7.3 - 2018-01-18
+### Changed
+- Allow a menu item's value to be any type of data, not just `number`
+
 ## 1.7.2 - 2018-01-17
 ### Added
 - SDDropDownMenu

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sd-material-ui",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sd-material-ui",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "StratoDem Analytics Dash implementation of material-ui components",
   "main": "lib/index.js",
   "repository": {

--- a/sd_material_ui/metadata.json
+++ b/sd_material_ui/metadata.json
@@ -970,7 +970,7 @@
             "type": {
               "name": "signature",
               "type": "object",
-              "raw": "{\n  checked?: boolean,\n  children?: Node,\n  disabled?: boolean,\n  label?: string,\n  primaryText: string,\n  secondaryText?: string,\n  style?: Object,\n  value: number,\n}",
+              "raw": "{\n  checked?: boolean,\n  children?: Node,\n  disabled?: boolean,\n  label?: string,\n  primaryText: string,\n  secondaryText?: string,\n  style?: Object,\n  value: any,\n}",
               "signature": {
                 "properties": [
                   {
@@ -1025,7 +1025,7 @@
                   {
                     "key": "value",
                     "value": {
-                      "name": "number",
+                      "name": "any",
                       "required": true
                     }
                   }
@@ -1316,7 +1316,7 @@
                 "required": false
               },
               "value": {
-                "name": "number",
+                "name": "any",
                 "description": "The value of the menu item.",
                 "required": true
               }
@@ -1331,7 +1331,7 @@
             {
               "name": "signature",
               "type": "object",
-              "raw": "{\n  checked?: boolean,\n  children?: Node,\n  disabled?: boolean,\n  label?: string,\n  primaryText: string,\n  secondaryText?: string,\n  style?: Object,\n  value: number,\n}",
+              "raw": "{\n  checked?: boolean,\n  children?: Node,\n  disabled?: boolean,\n  label?: string,\n  primaryText: string,\n  secondaryText?: string,\n  style?: Object,\n  value: any,\n}",
               "signature": {
                 "properties": [
                   {
@@ -1386,7 +1386,7 @@
                   {
                     "key": "value",
                     "value": {
-                      "name": "number",
+                      "name": "any",
                       "required": true
                     }
                   }

--- a/sd_material_ui/version.py
+++ b/sd_material_ui/version.py
@@ -9,4 +9,4 @@ Notes :
 December 28, 2017
 """
 
-__version__ = '1.7.2'
+__version__ = '1.7.3'

--- a/src/components/SDDropDownMenu.react.js
+++ b/src/components/SDDropDownMenu.react.js
@@ -17,7 +17,7 @@ type SD_MENU_ITEM = {
   primaryText: string,
   secondaryText?: string,
   style?: Object,
-  value: number,
+  value: any,
 }
 
 type Props = {
@@ -169,7 +169,7 @@ const propTypes = {
     /**
      * The value of the menu item.
      */
-    value: PropTypes.number.isRequired,
+    value: PropTypes.any.isRequired,
   })),
 
   /**

--- a/src/components/__tests__/SDDropDownMenu.test.js
+++ b/src/components/__tests__/SDDropDownMenu.test.js
@@ -16,8 +16,8 @@ describe('SDDropDownMenu', () => {
   it('updates value based on selections', () => {
     const component = mount(
       <SDDropDownMenu id='test-id' value={1}>
-        <MenuItem id='test-id2' value={1} primaryText='Test text' />
-        <MenuItem id='test-id3' value={2} primaryText='Test text' />
+        <MenuItem value={1} primaryText='Test text' />
+        <MenuItem value={2} primaryText='Test text' />
       </SDDropDownMenu>
     );
 

--- a/usage.py
+++ b/usage.py
@@ -114,11 +114,11 @@ app.layout = html.Div([
 
     # Test for SDDropDownMenu and SDMenuItem (single selection)
     sd_material_ui.SDDropDownMenu(id='input11',
-                                  value=1,
+                                  value=123,
                                   options=[
-                                      dict(value=1, primaryText='Item 1', label='First choice!'),
-                                      dict(value=2, primaryText='Item 2'),
-                                      dict(value=3, primaryText='Item 3', disabled=True,
+                                      dict(value='abc', primaryText='Item 1', label='First choice!'),
+                                      dict(value=123, primaryText='Item 2'),
+                                      dict(value={1: 'a'}, primaryText='Item 3', disabled=True,
                                            secondaryText='Disabled for now'),
                                   ],
                                   menuStyle=dict(width=200),
@@ -134,7 +134,7 @@ app.layout = html.Div([
 @app.callback(
     dash.dependencies.Output('output', 'children'),
     [dash.dependencies.Input('input', 'selectedIndex')])
-def display_output(value: int):
+def display_output(value):
     return 'You have entered {}'.format(value)
 
 
@@ -264,7 +264,10 @@ def click_snackbar(snackbar_click: str):
     [dash.dependencies.Input('input11', 'value')],
     [dash.dependencies.State('input11', 'options')])
 def dropdown_callback(value, options):
-    return ['Selection is: {}, {}'.format(value, options[value - 1]['primaryText'])]
+    for option in options:
+        if option['value'] == value:
+            text = option['primaryText']
+    return ['Selection is: {}, {}'.format(value, text)]
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description
This changes the `value` prop of a menu item so that it can take any type of data as its value instead of only the type `number`. 

#### Note
An important side effect of this change is that it may not always be possible to use a menu item's `value` as an index to grab that specific menu item from the list of options in the drop down menu. 

closes #32 

## How has this been tested?
All manual and automated tests have been run and have passed.