### PR TITLE
35 add wildcard prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.7.4 - 2018-01-19
+### Added
+- `customData` prop now available to menu items in SDDropDownMenu
+
 ## 1.7.3 - 2018-01-18
 ### Changed
 - Allow a menu item's value to be any type of data, not just `number`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sd-material-ui",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sd-material-ui",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "description": "StratoDem Analytics Dash implementation of material-ui components",
   "main": "lib/index.js",
   "repository": {

--- a/sd_material_ui/metadata.json
+++ b/sd_material_ui/metadata.json
@@ -970,7 +970,7 @@
             "type": {
               "name": "signature",
               "type": "object",
-              "raw": "{\n  checked?: boolean,\n  children?: Node,\n  disabled?: boolean,\n  label?: string,\n  primaryText: string,\n  secondaryText?: string,\n  style?: Object,\n  value: any,\n}",
+              "raw": "{\n  checked?: boolean,\n  children?: Node,\n  customData: any,\n  disabled?: boolean,\n  label?: string,\n  primaryText: string,\n  secondaryText?: string,\n  style?: Object,\n  value: any,\n}",
               "signature": {
                 "properties": [
                   {
@@ -985,6 +985,13 @@
                     "value": {
                       "name": "Node",
                       "required": false
+                    }
+                  },
+                  {
+                    "key": "customData",
+                    "value": {
+                      "name": "any",
+                      "required": true
                     }
                   },
                   {
@@ -1287,6 +1294,11 @@
                 "description": "Elements passed as children to the underlying `ListItem`.",
                 "required": false
               },
+              "customData": {
+                "name": "any",
+                "description": "A field able to hold any additional data a Dash user may want to include with a menu item,\nbut does not want rendered on screen.",
+                "required": false
+              },
               "disabled": {
                 "name": "bool",
                 "description": "If true, the menu item will be disabled.",
@@ -1331,7 +1343,7 @@
             {
               "name": "signature",
               "type": "object",
-              "raw": "{\n  checked?: boolean,\n  children?: Node,\n  disabled?: boolean,\n  label?: string,\n  primaryText: string,\n  secondaryText?: string,\n  style?: Object,\n  value: any,\n}",
+              "raw": "{\n  checked?: boolean,\n  children?: Node,\n  customData: any,\n  disabled?: boolean,\n  label?: string,\n  primaryText: string,\n  secondaryText?: string,\n  style?: Object,\n  value: any,\n}",
               "signature": {
                 "properties": [
                   {
@@ -1346,6 +1358,13 @@
                     "value": {
                       "name": "Node",
                       "required": false
+                    }
+                  },
+                  {
+                    "key": "customData",
+                    "value": {
+                      "name": "any",
+                      "required": true
                     }
                   },
                   {
@@ -1493,12 +1512,12 @@
       },
       "value": {
         "type": {
-          "name": "number"
+          "name": "any"
         },
         "required": true,
         "description": "The value of the selected menu item.",
         "flowType": {
-          "name": "number"
+          "name": "any"
         }
       }
     }

--- a/sd_material_ui/version.py
+++ b/sd_material_ui/version.py
@@ -9,4 +9,4 @@ Notes :
 December 28, 2017
 """
 
-__version__ = '1.7.3'
+__version__ = '1.7.4'

--- a/src/components/SDDropDownMenu.react.js
+++ b/src/components/SDDropDownMenu.react.js
@@ -12,6 +12,7 @@ import getMuiTheme from 'material-ui/styles/getMuiTheme';
 type SD_MENU_ITEM = {
   checked?: boolean,
   children?: Node,
+  customData: any,
   disabled?: boolean,
   label?: string,
   primaryText: string,
@@ -42,7 +43,7 @@ type Props = {
   style?: object,
   targetOrigin?: object,
   underlineStyle?: object,
-  value: number,
+  value: any,
 };
 
 const propTypes = {
@@ -140,6 +141,12 @@ const propTypes = {
     children: PropTypes.node,
 
     /**
+     * A field able to hold any additional data a Dash user may want to include with a menu item,
+     * but does not want rendered on screen.
+     */
+    customData: PropTypes.any,
+
+    /**
      * If true, the menu item will be disabled.
      */
     disabled: PropTypes.bool,
@@ -201,11 +208,11 @@ const propTypes = {
   /**
    * The value of the selected menu item.
    */
-  value: PropTypes.number.isRequired,
+  value: PropTypes.any.isRequired,
 };
 
 type State = {
-  value: number,
+  value: any,
 };
 
 const defaultProps = {
@@ -263,6 +270,7 @@ export default class SDDropDownMenu extends Component<Props, State> {
      */
     <MenuItem
       checked={item.checked}
+      customData={item.customData}
       disabled={item.disabled}
       label={item.label}
       primaryText={item.primaryText}

--- a/usage.py
+++ b/usage.py
@@ -125,7 +125,7 @@ app.layout = html.Div([
                                                secondaryText='Disabled for now'),
                                       ],
                                       menuStyle=dict(width=200),  # controls style of the open menu
-                                      labelStyle=dict(color='white'),
+                                      labelStyle=dict(color='white', height=35),
                                       underlineStyle=dict(display='none'),
                                       autoWidth=False,
                                       style=dict(height=40, marginTop=-10),

--- a/usage.py
+++ b/usage.py
@@ -113,17 +113,27 @@ app.layout = html.Div([
     spacer,
 
     # Test for SDDropDownMenu and SDMenuItem (single selection)
-    sd_material_ui.SDDropDownMenu(id='input11',
-                                  value=123,
-                                  options=[
-                                      dict(value='abc', primaryText='Item 1', label='First choice!'),
-                                      dict(value=123, primaryText='Item 2'),
-                                      dict(value={1: 'a'}, primaryText='Item 3', disabled=True,
-                                           secondaryText='Disabled for now'),
-                                  ],
-                                  menuStyle=dict(width=200),
-                                  anchorOrigin=dict(vertical='bottom', horizontal='right'),
-                                  openImmediately=True),
+    html.Div(children=[
+        sd_material_ui.SDDropDownMenu(id='input11',
+                                      value=1,
+                                      options=[
+                                          dict(value=1, primaryText='Item 1',
+                                               label='First choice!', customData='Anything!'),
+                                          dict(value=2, primaryText='Item 2',
+                                               customData={'foo': 'bar'}),
+                                          dict(value=3, primaryText='Item 3', disabled=True,
+                                               secondaryText='Disabled for now'),
+                                      ],
+                                      menuStyle=dict(width=200),  # controls style of the open menu
+                                      labelStyle=dict(color='white'),
+                                      underlineStyle=dict(display='none'),
+                                      autoWidth=False,
+                                      style=dict(height=40, marginTop=-10),
+                                      iconStyle=dict(padding=0),
+                                      listStyle=dict(height=35),
+                                      selectedMenuItemStyle=dict(height=30),
+                                      anchorOrigin=dict(vertical='bottom', horizontal='right')),
+    ], style=dict(backgroundColor='#1D3153')),
     html.Div(id='output11', children=['Selected item appears here.']),
 
     final_spacer,
@@ -264,10 +274,7 @@ def click_snackbar(snackbar_click: str):
     [dash.dependencies.Input('input11', 'value')],
     [dash.dependencies.State('input11', 'options')])
 def dropdown_callback(value, options):
-    for option in options:
-        if option['value'] == value:
-            text = option['primaryText']
-    return ['Selection is: {}, {}'.format(value, text)]
+    return ['Selection is: {}, {}'.format(value, options[value - 1]['customData'])]
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description
Adds a new prop, `customData` to menu items in SDDropDownMenu. This prop can be used to pass data along with each menu item that is available to a Dash user, but is not rendered to the screen. It also frees up `value` to be used more simply as an index.

closes #35 

## How has this been tested?
All manual and automated tests have run and passed.