### PR TITLE
37 patch dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.7.5 - 2018-01-23
+### Changed
+- Removed `null` default for SDDropDownMenu's `iconButton`, allowing the arrow to appear by default
+
 ## 1.7.4 - 2018-01-19
 ### Added
 - `customData` prop now available to menu items in SDDropDownMenu

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sd-material-ui",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sd-material-ui",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "description": "StratoDem Analytics Dash implementation of material-ui components",
   "main": "lib/index.js",
   "repository": {

--- a/sd_material_ui/metadata.json
+++ b/sd_material_ui/metadata.json
@@ -1149,10 +1149,6 @@
         "description": "Overrides default SvgIcon dropdown arrow component.",
         "flowType": {
           "name": "Node"
-        },
-        "defaultValue": {
-          "value": "null",
-          "computed": false
         }
       },
       "iconStyle": {

--- a/sd_material_ui/version.py
+++ b/sd_material_ui/version.py
@@ -9,4 +9,4 @@ Notes :
 December 28, 2017
 """
 
-__version__ = '1.7.4'
+__version__ = '1.7.5'

--- a/src/components/SDDropDownMenu.react.js
+++ b/src/components/SDDropDownMenu.react.js
@@ -222,7 +222,6 @@ const defaultProps = {
   className: '',
   disabled: false,
   fireEvent: () => {},
-  // iconButton: null,
   iconStyle: {},
   labelStyle: {},
   listStyle: {},

--- a/src/components/SDDropDownMenu.react.js
+++ b/src/components/SDDropDownMenu.react.js
@@ -222,7 +222,7 @@ const defaultProps = {
   className: '',
   disabled: false,
   fireEvent: () => {},
-  iconButton: null,
+  // iconButton: null,
   iconStyle: {},
   labelStyle: {},
   listStyle: {},

--- a/usage.py
+++ b/usage.py
@@ -71,7 +71,10 @@ app.layout = html.Div([
     spacer,
 
     # Test for SDDrawer (docked, secondary)
-    sd_material_ui.SDDrawer(id='output6', docked=True, openSecondary=True,
+    sd_material_ui.SDDrawer(id='output6',
+                            docked=True,
+                            openSecondary=True,
+                            style={'backgroundColor': '#444'},
                             children=[html.P(children='Drawer item')]),
     html.Div(id='input6', children=[
         html.P(children='Open or close the drawer (docked)')
@@ -129,7 +132,6 @@ app.layout = html.Div([
                                       underlineStyle=dict(display='none'),
                                       autoWidth=False,
                                       style=dict(height=40, marginTop=-10),
-                                      iconStyle=dict(padding=0),
                                       listStyle=dict(height=35),
                                       selectedMenuItemStyle=dict(height=30),
                                       anchorOrigin=dict(vertical='bottom', horizontal='right')),


### PR DESCRIPTION
## Description
This patch removes a `null` default in SDDropDownMenu, now allowing the down-arrow icon to appear next to the menu by default.

closes #37 

## How has this been tested?
All automated and manual tests have been run and have passed.