### PR TITLE
62 icon btn component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,19 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.5.0 - 2018-03-15
+### Added
+- Add IconButton Component
+
+### Changed
+- Change `usage.py` test-buttons-together tests to include IconButton
+
 ## 2.4.0 - 2018-03-14
 ### Added
 - Add CircularProgress Component
 
 ### Changed
-- Change usage.py button test to avoid NoneType Error
+- Change `usage.py` button test to avoid NoneType Error
 
 ## 2.3.1 - 2018-03-13
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Add CircularProgress Component
 
 ### Changed
-- Change usage.py button test to avoid NoneType Erro
+- Change usage.py button test to avoid NoneType Error
 
 ## 2.3.1 - 2018-03-13
 ### Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sd-material-ui",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sd-material-ui",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "StratoDem Analytics Dash implementation of material-ui components",
   "main": "lib/index.js",
   "repository": {

--- a/sd_material_ui/metadata.json
+++ b/sd_material_ui/metadata.json
@@ -1657,6 +1657,231 @@
       }
     }
   },
+  "src/components/IconButton/IconButton.react.js": {
+    "description": "",
+    "displayName": "IconButton",
+    "methods": [
+      {
+        "name": "handleClick",
+        "docblock": null,
+        "modifiers": [],
+        "params": [],
+        "returns": null
+      }
+    ],
+    "props": {
+      "children": {
+        "flowType": {
+          "name": "Node"
+        },
+        "required": false,
+        "description": "Used to pass a FontIcon element as the icon for the button\nSee method 3 at http://www.material-ui.com/#/components/icon-button",
+        "defaultValue": {
+          "value": "null",
+          "computed": false
+        }
+      },
+      "className": {
+        "flowType": {
+          "name": "string"
+        },
+        "required": false,
+        "description": "The CSS class name of the root element",
+        "defaultValue": {
+          "value": "''",
+          "computed": false
+        }
+      },
+      "disableTouchRipple": {
+        "flowType": {
+          "name": "boolean"
+        },
+        "required": false,
+        "description": "If true, the element's ripple effect will be disabled",
+        "defaultValue": {
+          "value": "false",
+          "computed": false
+        }
+      },
+      "disabled": {
+        "flowType": {
+          "name": "boolean"
+        },
+        "required": false,
+        "description": "Disable the button?",
+        "defaultValue": {
+          "value": "false",
+          "computed": false
+        }
+      },
+      "fireEvent": {
+        "flowType": {
+          "name": "signature",
+          "type": "function",
+          "raw": "() => void",
+          "signature": {
+            "arguments": [],
+            "return": {
+              "name": "void"
+            }
+          }
+        },
+        "required": false,
+        "description": "Dash callback to trigger an event handler",
+        "defaultValue": {
+          "value": "() => {}",
+          "computed": false
+        }
+      },
+      "hoveredStyle": {
+        "flowType": {
+          "name": "Object"
+        },
+        "required": false,
+        "description": "Override the inline-styles of the root element when the component is hovered",
+        "defaultValue": {
+          "value": "{}",
+          "computed": false
+        }
+      },
+      "href": {
+        "flowType": {
+          "name": "string"
+        },
+        "required": false,
+        "description": "The URL to link to when the button is clicked",
+        "defaultValue": {
+          "value": "''",
+          "computed": false
+        }
+      },
+      "iconClassName": {
+        "flowType": {
+          "name": "string"
+        },
+        "required": false,
+        "description": "The CSS class name of the icon. Used for setting the icon with a stylesheet",
+        "defaultValue": {
+          "value": "'material-icons'",
+          "computed": false
+        }
+      },
+      "iconStyle": {
+        "flowType": {
+          "name": "Object"
+        },
+        "required": false,
+        "description": "Override the inline-styles of the icon element.\nNote: you can specify iconHoverColor as a String inside this object.",
+        "defaultValue": {
+          "value": "{}",
+          "computed": false
+        }
+      },
+      "id": {
+        "flowType": {
+          "name": "string"
+        },
+        "required": false,
+        "description": "Element ID"
+      },
+      "n_clicks": {
+        "flowType": {
+          "name": "number"
+        },
+        "required": false,
+        "description": "An integer that represents the number fo times that this element has been clicked",
+        "defaultValue": {
+          "value": "0",
+          "computed": false
+        }
+      },
+      "n_clicks_previous": {
+        "flowType": {
+          "name": "number"
+        },
+        "required": false,
+        "description": "An integer that represents the previous number of times this element has been clicked",
+        "defaultValue": {
+          "value": "0",
+          "computed": false
+        }
+      },
+      "setProps": {
+        "flowType": {
+          "name": "signature",
+          "type": "function",
+          "raw": "() => void",
+          "signature": {
+            "arguments": [],
+            "return": {
+              "name": "void"
+            }
+          }
+        },
+        "required": false,
+        "description": "Dash callback to update props",
+        "defaultValue": {
+          "value": "() => {}",
+          "computed": false
+        }
+      },
+      "style": {
+        "flowType": {
+          "name": "Object"
+        },
+        "required": false,
+        "description": "Override the inline-styles of the root element.",
+        "defaultValue": {
+          "value": "{}",
+          "computed": false
+        }
+      },
+      "tooltip": {
+        "flowType": {
+          "name": "Node"
+        },
+        "required": false,
+        "description": "The text to supply to the element's tooltip",
+        "defaultValue": {
+          "value": "''",
+          "computed": false
+        }
+      },
+      "tooltipPosition": {
+        "flowType": {
+          "name": "unknown"
+        },
+        "required": false,
+        "description": "The vertical and horizontal positions, respectively, of the element's tooltip.\nPossible values are: \"bottom-center\", \"top-center\", \"bottom-right\", \"top-right\",\n\"bottom-left\", and \"top-left\".",
+        "defaultValue": {
+          "value": "'bottom-center'",
+          "computed": false
+        }
+      },
+      "tooltipStyles": {
+        "flowType": {
+          "name": "Object"
+        },
+        "required": false,
+        "description": "Override the inline-styles of the tooltip element",
+        "defaultValue": {
+          "value": "{}",
+          "computed": false
+        }
+      },
+      "touch": {
+        "flowType": {
+          "name": "boolean"
+        },
+        "required": false,
+        "description": "If true, increase the tooltip element's size.\nUseful for increasing tooltip readability on mobile devices.",
+        "defaultValue": {
+          "value": "false",
+          "computed": false
+        }
+      }
+    }
+  },
   "src/components/RaisedButton/RaisedButton.react.js": {
     "description": "",
     "displayName": "RaisedButton",

--- a/sd_material_ui/version.py
+++ b/sd_material_ui/version.py
@@ -9,4 +9,4 @@ Notes :
 December 28, 2017
 """
 
-__version__ = '2.4.0'
+__version__ = '2.5.0'

--- a/src/components/IconButton/IconButton.react.js
+++ b/src/components/IconButton/IconButton.react.js
@@ -1,0 +1,140 @@
+// @flow
+
+import React, { Component } from 'react';
+
+import MuiIconButton from 'material-ui/FlatButton';
+import lightBaseTheme from 'material-ui/styles/baseThemes/lightBaseTheme';
+import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
+import getMuiTheme from 'material-ui/styles/getMuiTheme';
+
+type Props = {
+  /** Can be used to pass a FontIcon element as the icon for the button */
+  children?: Node,
+  /** The CSS class name of the root element */
+  className?: string,
+  /** If true, the element's ripple effect will be disabled */
+  disableTouchRipple?: boolean,
+  /** Disable the button? */
+  disabled?: boolean,
+  /** Dash callback to trigger an event handler */
+  fireEvent?: () => void,
+  /** Override the inline-styles of the root element when the component is hovered */
+  hoveredStyle?: Object,
+  /** The URL to link to when the button is clicked */
+  href?: string,
+  /** The CSS class name of the icon. Used for setting the icon with a stylesheet */
+  iconClassName?: string,
+  /** Override the inline-styles of the icon element.
+   * Note: you can specify iconHoverColor as a String inside this object.
+   */
+  iconStyle?: Object,
+  /** Element ID */
+  id?: string,
+  /** An integer that represents the number fo times that this element has been clicked */
+  n_clicks?: number,
+  /** An integer that represents the previous number of times this element has been clicked */
+  n_clicks_previous?: number,
+  /** Dash callback to update props */
+  setProps?: () => void,
+  /** Override the inline-styles of the root element. */
+  style?: Object,
+  /** The text to supply to the element's tooltip */
+  tooltip?: Node,
+  /** The vertical and horizontal positions, respectively, of the element's tooltip.
+   * Possible values are: "bottom-center", "top-center", "bottom-right", "top-right",
+   * "bottom-left", and "top-left".
+   */
+  tooltipPosition?: propTypes.cornersAndCenter,
+  /** Override the inline-styles of the tooltip element */
+  tooltipStyles?: Object,
+  /** If true, increase the tooltip element's size.
+   * Useful for increasing tooltip readability on mobile devices.
+   */
+  touch?: boolean,
+};
+
+const defaultProps = {
+  children: null,
+  className: '',
+  disableTouchRipple: false,
+  disabled: false,
+  fireEvent: () => {},
+  hoveredStyle: {},
+  href: '',
+  iconClassName: '',
+  iconStyle: {},
+  n_clicks: 0,
+  n_clicks_previous: 0,
+  setProps: () => {},
+  style: {},
+  tooltip: '',
+  tooltipPosition: 'bottom-center',
+  tooltipStyles: {},
+  touch: false,
+};
+
+export default class IconButton extends Component<Props> {
+  constructor(props: Props) {
+    super(props);
+    this.handleClick = this.handleClick.bind(this);
+  }
+
+  handleClick() {
+    if (this.props.setProps) this.props.setProps({n_clicks: this.props.n_clicks + 1});
+    if (this.props.fireEvent) this.props.fireEvent({event: 'click'});
+    if (this.props.setProps) this.props.setProps({n_clicks_previous: this.props.n_clicks + 1});
+  }
+
+  render() {
+    const {className, disableTouchRipple, disabled, hoveredStyle, href, iconClassName,
+      iconStyle, id, style, tooltip, tooltipPosition, tooltipStyles, touch} = this.props;
+
+    if (this.props.fireEvent || this.props.setProps) {
+      return (
+        <div id={id}>
+          <MuiThemeProvider muiTheme={getMuiTheme(lightBaseTheme)}>
+            <MuiIconButton
+              className={className}
+              disableTouchRipple={disableTouchRipple}
+              disabled={disabled}
+              hoveredStyle={hoveredStyle}
+              href={href}
+              iconClassName={iconClassName}
+              iconStyle={iconStyle}
+              onClick={this.handleClick}
+              style={style}
+              tooltip={tooltip}
+              tooltipPosition={tooltipPosition}
+              tooltipStyles={tooltipStyles}
+              touch={touch}
+            >
+              {this.props.children}
+            </MuiIconButton>
+          </MuiThemeProvider>
+        </div>);
+    }
+    return (
+      <div id={id}>
+        <MuiThemeProvider muiTheme={getMuiTheme(lightBaseTheme)}>
+          <MuiIconButton
+            className={className}
+            disableTouchRipple={disableTouchRipple}
+            disabled={disabled}
+            hoveredStyle={hoveredStyle}
+            href={href}
+            iconClassName={iconClassName}
+            iconStyle={iconStyle}
+            style={style}
+            tooltip={tooltip}
+            tooltipPosition={tooltipPosition}
+            tooltipStyles={tooltipStyles}
+            touch={touch}
+          >
+            {this.props.children}
+          </MuiIconButton>
+        </MuiThemeProvider>
+      </div>);
+  }
+}
+
+IconButton.defaultProps = defaultProps;

--- a/src/components/IconButton/IconButton.react.js
+++ b/src/components/IconButton/IconButton.react.js
@@ -2,13 +2,15 @@
 
 import React, { Component } from 'react';
 
-import MuiIconButton from 'material-ui/FlatButton';
+import MuiIconButton from 'material-ui/IconButton';
 import lightBaseTheme from 'material-ui/styles/baseThemes/lightBaseTheme';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import getMuiTheme from 'material-ui/styles/getMuiTheme';
 
 type Props = {
-  /** Can be used to pass a FontIcon element as the icon for the button */
+  /** Used to pass a FontIcon element as the icon for the button
+   * See method 3 at http://www.material-ui.com/#/components/icon-button
+   */
   children?: Node,
   /** The CSS class name of the root element */
   className?: string,
@@ -61,7 +63,7 @@ const defaultProps = {
   fireEvent: () => {},
   hoveredStyle: {},
   href: '',
-  iconClassName: '',
+  iconClassName: 'material-icons',
   iconStyle: {},
   n_clicks: 0,
   n_clicks_previous: 0,

--- a/src/components/IconButton/index.js
+++ b/src/components/IconButton/index.js
@@ -1,0 +1,3 @@
+import IconButton from './IconButton.react';
+
+export default IconButton;

--- a/src/components/__tests__/IconButton.test.js
+++ b/src/components/__tests__/IconButton.test.js
@@ -1,0 +1,78 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import IconButton from '../IconButton/IconButton.react';
+import MuiIconButton from 'material-ui/IconButton';
+
+describe('IconButton', () => {
+  it('renders', () => {
+    const component = shallow(
+      <IconButton id='test-id' label='myButton'>
+        children=
+        <div>
+          <p>Button text</p>
+        </div>
+      </IconButton>);
+
+    expect(component.props().id).toEqual('test-id');
+    expect(component).toBe.ok;
+  });
+
+  it('handles click events', () => {
+    const clickCheck = jest.fn();
+    const component = shallow(
+      <IconButton id='test-id' label='myButton' fireEvent={clickCheck} />);
+
+    component.find(MuiIconButton).simulate('click');
+    expect(clickCheck.mock.calls.length).toEqual(1);
+  });
+
+  it('renders children when passed in', () => {
+    const component = shallow(
+      <IconButton id='test-id' label='myButton'>
+        children=<div className='myDiv' />
+      </IconButton>);
+
+    expect(component.contains(<div className="myDiv" />)).toEqual(true);
+  });
+
+  it('uses the styles provided', () => {
+    const component = shallow(
+      <IconButton
+        id='test-id'
+        label='myButton'
+        iconStyle={{'color':'black'}}
+        iconClassName='material-icons'
+      >
+        children={['help']}
+      </IconButton>);
+
+    expect(component.find(MuiIconButton).props().iconStyle).toEqual({'color': 'black'});
+    expect(component.find(MuiIconButton).props().iconClassName).toEqual('material-icons');
+  });
+
+  it('renders with no callbacks', () => {
+    const blankFunc = () => { return null; };
+    const component = shallow(
+      <IconButton id='test-id' label='myButton' fireEvent={blankFunc} setProps={blankFunc} />);
+
+    expect(component).toBe.ok;
+  });
+
+  it('increments n_clicks', () => {
+    const mockProps = jest.fn();
+    const component = shallow(
+      <IconButton id='test-id' label='myButton' n_clicks={1} setProps={mockProps} />);
+
+    component.find(MuiIconButton).simulate('click');
+    expect(mockProps).toHaveBeenCalledWith({n_clicks: 2});
+  });
+
+  it('increments n_clicks_previous', () => {
+    const mockProps = jest.fn();
+    const component = shallow(
+      <IconButton id='test-id' label='myButton' n_clicks={1} n_clicks_previous={1} setProps={mockProps} />);
+
+    component.find(MuiIconButton).simulate('click');
+    expect(mockProps).toHaveBeenCalledWith({n_clicks_previous: 2});
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import Divider from './components/Divider';
 import Drawer from './components/Drawer';
 import DropDownMenu from './components/DropDownMenu';
 import FlatButton from './components/FlatButton';
+import IconButton from './components/IconButton';
 import Snackbar from './components/Snackbar';
 import RaisedButton from './components/RaisedButton';
 import Toggle from './components/Toggle';
@@ -19,6 +20,7 @@ export {
   Drawer,
   DropDownMenu,
   FlatButton,
+  IconButton,
   Snackbar,
   RaisedButton,
   Toggle,

--- a/usage.py
+++ b/usage.py
@@ -90,12 +90,17 @@ app.layout = html.Div([
     html.Div(children=[
         html.P(id='output12', children=['n_clicks value: . n_clicks_previous value: '])
     ]),
-    sd_material_ui.IconButton(id='input12',)
+    sd_material_ui.IconButton(id='input12', children=['help'],
+                              iconStyle={'color':'orange', 'width': 48, 'height': 48},
+                              tooltip='click for more information', touch=True,
+                              tooltipPosition='bottom-right'),
 
     # Test buttons together to see which was clicked
     html.Div(children=[
-        html.P(id='output4-5', children=['Which button was clicked? ']),
-        html.P(id='output4-5-b', children=['Clicked values for flat () and raised () buttons'])
+        html.P(id='output4-5-12',
+               children=['Which button was clicked? ']),
+        html.P(id='output4-5-12-b',
+               children=['Clicked values for flat () and raised () and icon () buttons'])
     ]),
 
     spacer,
@@ -236,40 +241,64 @@ def display_clicks_flat(n_clicks_flat: int, n_clicks_flat_prev: int):
         return ['n_clicks value: ']
 
 
+# Callback for SDIconButton
+@app.callback(
+    dash.dependencies.Output('output12', 'children'),
+    [dash.dependencies.Input('input12', 'n_clicks')],
+    [dash.dependencies.State('input12', 'n_clicks_previous')])
+def display_clicks_icon(n_clicks_icon: int, n_clicks_icon_prev: int):
+    if n_clicks_icon:
+        return ['n_clicks value: {}. n_clicks_prev value: {}'.format(n_clicks_icon,
+                                                                     n_clicks_icon_prev)]
+    else:
+        return ['n_clicks value: ']
+
+
 # Callback for combined button test
 @app.callback(
-    dash.dependencies.Output('output4-5', 'children'),
+    dash.dependencies.Output('output4-5-12', 'children'),
     [dash.dependencies.Input('input4', 'n_clicks'),
-     dash.dependencies.Input('input5', 'n_clicks')],
+     dash.dependencies.Input('input5', 'n_clicks'),
+     dash.dependencies.Input('input12', 'n_clicks')],
     [dash.dependencies.State('input4', 'n_clicks_previous'),
-     dash.dependencies.State('input5', 'n_clicks_previous')])
-def determine_button_callback(raised_n_clicks: int, flat_n_clicks: int,
-                              raised_n_clicks_prev: int, flat_n_clicks_prev: int) -> list:
-    if raised_n_clicks is None and flat_n_clicks is None:
+     dash.dependencies.State('input5', 'n_clicks_previous'),
+     dash.dependencies.State('input12', 'n_clicks_previous')])
+def determine_button_callback(raised_n_clicks: int, flat_n_clicks: int, icon_n_clicks: int,
+                              raised_n_clicks_prev: int, flat_n_clicks_prev: int,
+                              icon_n_clicks_prev: int) -> list:
+    if raised_n_clicks is None and flat_n_clicks is None and icon_n_clicks is None:
         return ['Which button was clicked?']
     elif raised_n_clicks is not None and not raised_n_clicks_prev:
         return ['Which button was clicked? Raised button']
     elif flat_n_clicks is not None and not flat_n_clicks_prev:
         return ['Which button was clicked? Flat button']
+    elif icon_n_clicks is not None and not icon_n_clicks_prev:
+        return ['Which button was clicked? Icon button']
     elif raised_n_clicks > raised_n_clicks_prev:
         return ['Which button was clicked? Raised button']
     elif flat_n_clicks > flat_n_clicks_prev:
         return ['Which button was clicked? Flat button']
+    elif icon_n_clicks > icon_n_clicks_prev:
+        return ['Which button was clicked? Icon button']
     else:
         return ['Which button was clicked? ']
 
 
 # Callback for combined button test secondary
 @app.callback(
-    dash.dependencies.Output('output4-5-b', 'children'),
+    dash.dependencies.Output('output4-5-12-b', 'children'),
     [dash.dependencies.Input('input4', 'n_clicks'),
-     dash.dependencies.Input('input5', 'n_clicks')],
+     dash.dependencies.Input('input5', 'n_clicks'),
+     dash.dependencies.Input('input12', 'n_clicks')],
     [dash.dependencies.State('input4', 'n_clicks_previous'),
-     dash.dependencies.State('input5', 'n_clicks_previous')])
-def determine_button_callback(raised_n_clicks: int, flat_n_clicks: int,
-                              raised_n_clicks_prev: int, flat_n_clicks_prev: int) -> list:
-    return ['Clicked values for flat ({}-{}) and raised ({}-{}) buttons'.format(
-        flat_n_clicks, flat_n_clicks_prev, raised_n_clicks, raised_n_clicks_prev)]
+     dash.dependencies.State('input5', 'n_clicks_previous'),
+     dash.dependencies.State('input12', 'n_clicks_previous')])
+def determine_button_callback(raised_n_clicks: int, flat_n_clicks: int, icon_n_clicks: int,
+                              raised_n_clicks_prev: int, flat_n_clicks_prev: int,
+                              icon_n_clicks_prev: int) -> list:
+    return ['Clicked values for flat ({}-{}) and raised ({}-{}) and icon ({}-{}) buttons'.format(
+        flat_n_clicks, flat_n_clicks_prev, raised_n_clicks,
+        raised_n_clicks_prev, icon_n_clicks, icon_n_clicks_prev)]
 
 
 # Callback for SDDrawer (docked, secondary)

--- a/usage.py
+++ b/usage.py
@@ -86,6 +86,12 @@ app.layout = html.Div([
     ]),
     sd_material_ui.FlatButton(id='input5', label='Click me', backgroundColor='orange'),
 
+    # Test SDIconButton
+    html.Div(children=[
+        html.P(id='output12', children=['n_clicks value: . n_clicks_previous value: '])
+    ]),
+    sd_material_ui.IconButton(id='input12',)
+
     # Test buttons together to see which was clicked
     html.Div(children=[
         html.P(id='output4-5', children=['Which button was clicked? ']),


### PR DESCRIPTION
## Description
Built basic icon button component (able to use [material-icons](https://material.io/icons/) when passed in as children)
includes styling and callback properties
Updated tests for usage.py for testing buttons together to include IconButton

## How Was This Tested?
Tested using manual usage.py by adding dash IconButton component to dash application.
Tested using automated IconButton.test.js by creating shallow component and testing for 'renders', 'uses styles provided', and handling of callbacks and children

## Screenshot
![iconbtncomponent mov](https://user-images.githubusercontent.com/14964817/37470500-0958d834-283e-11e8-8ce3-4246ba200f31.gif)


