### PR TITLE
50 card working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## 2.12.0 - 2014-04-19
+## 2.12.0 - 2018-05-17
+### Added
+- Adds uncontrolled Card component
+
+## 2.12.0 - 2018-04-19
 ### Changed
 - Adds functionality to `AutoComplete` component to allow for sending back `value` instead of `searchText`
 
@@ -28,7 +32,7 @@ sd_material_ui.AutoComplete(
     filter='caseSensitiveFilter')
 ```
 
-## 2.11.1 - 2014-04-19
+## 2.11.1 - 2018-04-19
 ### Fixes
 - Updates `metadata.json` for new props in `v2.11.0`
 

--- a/sd_material_ui/metadata.json
+++ b/sd_material_ui/metadata.json
@@ -743,6 +743,464 @@
       }
     }
   },
+  "src/components/Card/Card.react.js": {
+    "description": "",
+    "displayName": "Card",
+    "methods": [
+      {
+        "name": "handleExpandChange",
+        "docblock": null,
+        "modifiers": [],
+        "params": [
+          {
+            "name": "expanded",
+            "type": {
+              "name": "boolean"
+            }
+          }
+        ],
+        "returns": null
+      }
+    ],
+    "props": {
+      "children": {
+        "flowType": {
+          "name": "Node"
+        },
+        "required": false,
+        "description": "Can be used to render elements inside the Card.",
+        "defaultValue": {
+          "value": "[]",
+          "computed": false
+        }
+      },
+      "className": {
+        "flowType": {
+          "name": "string"
+        },
+        "required": false,
+        "description": "The CSS class name of the root element",
+        "defaultValue": {
+          "value": "''",
+          "computed": false
+        }
+      },
+      "containerStyle": {
+        "flowType": {
+          "name": "Object"
+        },
+        "required": false,
+        "description": "Override the inline-styles of the container element.",
+        "defaultValue": {
+          "value": "{}",
+          "computed": false
+        }
+      },
+      "expandable": {
+        "flowType": {
+          "name": "boolean"
+        },
+        "required": true,
+        "description": "If true, this card component is expandable."
+      },
+      "expanded": {
+        "flowType": {
+          "name": "boolean"
+        },
+        "required": true,
+        "description": "Whether this card is expanded."
+      },
+      "id": {
+        "flowType": {
+          "name": "string"
+        },
+        "required": true,
+        "description": "Component ID"
+      },
+      "initiallyExpanded": {
+        "flowType": {
+          "name": "boolean"
+        },
+        "required": false,
+        "description": "Whether this card is initially expanded.",
+        "defaultValue": {
+          "value": "false",
+          "computed": false
+        }
+      },
+      "setProps": {
+        "flowType": {
+          "name": "signature",
+          "type": "function",
+          "raw": "() => void",
+          "signature": {
+            "arguments": [],
+            "return": {
+              "name": "void"
+            }
+          }
+        },
+        "required": false,
+        "description": "Dash callback to update props",
+        "defaultValue": {
+          "value": "() => {}",
+          "computed": false
+        }
+      },
+      "style": {
+        "flowType": {
+          "name": "Object"
+        },
+        "required": false,
+        "description": "Override the inline-styles of the root element.",
+        "defaultValue": {
+          "value": "{}",
+          "computed": false
+        }
+      },
+      "headerAvatar": {
+        "flowType": {
+          "name": "Node"
+        },
+        "required": false,
+        "description": "This is the Avatar element to be displayed on the Card Header. If avatar is an Avatar or\nother element, it will be rendered. If avatar is a string, it will be used as the image src\nfor an Avatar.",
+        "defaultValue": {
+          "value": "[]",
+          "computed": false
+        }
+      },
+      "headerChildren": {
+        "flowType": {
+          "name": "Node"
+        },
+        "required": false,
+        "description": "Can be used to render elements inside the Card Header.",
+        "defaultValue": {
+          "value": "[]",
+          "computed": false
+        }
+      },
+      "headerStyle": {
+        "flowType": {
+          "name": "Object"
+        },
+        "required": false,
+        "description": "Override the inline-styles of the root element.",
+        "defaultValue": {
+          "value": "{}",
+          "computed": false
+        }
+      },
+      "headerSubtitle": {
+        "flowType": {
+          "name": "Node"
+        },
+        "required": false,
+        "description": "Can be used to render a subtitle in Card Header.",
+        "defaultValue": {
+          "value": "[]",
+          "computed": false
+        }
+      },
+      "headerSubtitleColor": {
+        "flowType": {
+          "name": "string"
+        },
+        "required": false,
+        "description": "Override the subtitle color.",
+        "defaultValue": {
+          "value": "''",
+          "computed": false
+        }
+      },
+      "headerSubtitleStyle": {
+        "flowType": {
+          "name": "Object"
+        },
+        "required": false,
+        "description": "Override the inline-styles of the subtitle.",
+        "defaultValue": {
+          "value": "{}",
+          "computed": false
+        }
+      },
+      "headerTextStyle": {
+        "flowType": {
+          "name": "Object"
+        },
+        "required": false,
+        "description": "Override the inline-styles of the text.",
+        "defaultValue": {
+          "value": "{}",
+          "computed": false
+        }
+      },
+      "headerTitle": {
+        "flowType": {
+          "name": "Node"
+        },
+        "required": false,
+        "description": "Can be used to render a title in Card Header.",
+        "defaultValue": {
+          "value": "[]",
+          "computed": false
+        }
+      },
+      "headerTitleColor": {
+        "flowType": {
+          "name": "string"
+        },
+        "required": false,
+        "description": "Override the title color.",
+        "defaultValue": {
+          "value": "''",
+          "computed": false
+        }
+      },
+      "headerTitleStyle": {
+        "flowType": {
+          "name": "Object"
+        },
+        "required": false,
+        "description": "Override the inline-styles of the title.",
+        "defaultValue": {
+          "value": "{}",
+          "computed": false
+        }
+      },
+      "mediaChildren": {
+        "flowType": {
+          "name": "Node"
+        },
+        "required": false,
+        "description": "Can be used to render elements inside the Card Media.",
+        "defaultValue": {
+          "value": "[]",
+          "computed": false
+        }
+      },
+      "mediaMediaStyle": {
+        "flowType": {
+          "name": "Object"
+        },
+        "required": false,
+        "description": "Override the inline-styles of the Card Media.",
+        "defaultValue": {
+          "value": "{}",
+          "computed": false
+        }
+      },
+      "mediaOverlay": {
+        "flowType": {
+          "name": "Node"
+        },
+        "required": false,
+        "description": "Can be used to render overlay element in Card Media.",
+        "defaultValue": {
+          "value": "[]",
+          "computed": false
+        }
+      },
+      "mediaOverlayContainerStyle": {
+        "flowType": {
+          "name": "Object"
+        },
+        "required": false,
+        "description": "Override the inline-styles of the overlay container.",
+        "defaultValue": {
+          "value": "{}",
+          "computed": false
+        }
+      },
+      "mediaContentStyle": {
+        "flowType": {
+          "name": "Object"
+        },
+        "required": false,
+        "description": "Override the inline-styles of the overlay content.",
+        "defaultValue": {
+          "value": "{}",
+          "computed": false
+        }
+      },
+      "mediaOverlayStyle": {
+        "flowType": {
+          "name": "Object"
+        },
+        "required": false,
+        "description": "Override the inline-styles of the overlay element.",
+        "defaultValue": {
+          "value": "{}",
+          "computed": false
+        }
+      },
+      "mediaStyle": {
+        "flowType": {
+          "name": "Object"
+        },
+        "required": false,
+        "description": "Override the inline-styles of the root element.",
+        "defaultValue": {
+          "value": "{}",
+          "computed": false
+        }
+      },
+      "textChildrenBeforeMedia": {
+        "flowType": {
+          "name": "Node"
+        },
+        "required": false,
+        "description": "Can be used to render elements inside the Card Text.",
+        "defaultValue": {
+          "value": "[]",
+          "computed": false
+        }
+      },
+      "textColorBeforeMedia": {
+        "flowType": {
+          "name": "string"
+        },
+        "required": false,
+        "description": "Override the CardText color.",
+        "defaultValue": {
+          "value": "''",
+          "computed": false
+        }
+      },
+      "textStyleBeforeMedia": {
+        "flowType": {
+          "name": "Object"
+        },
+        "required": false,
+        "description": "Override the inline-styles of the root element.",
+        "defaultValue": {
+          "value": "{}",
+          "computed": false
+        }
+      },
+      "textChildrenAfterMedia": {
+        "flowType": {
+          "name": "Node"
+        },
+        "required": false,
+        "description": "Can be used to render elements inside the Card Text.",
+        "defaultValue": {
+          "value": "[]",
+          "computed": false
+        }
+      },
+      "textColorAfterMedia": {
+        "flowType": {
+          "name": "string"
+        },
+        "required": false,
+        "description": "Override the CardText color.",
+        "defaultValue": {
+          "value": "''",
+          "computed": false
+        }
+      },
+      "textStyleAfterMedia": {
+        "flowType": {
+          "name": "Object"
+        },
+        "required": false,
+        "description": "Override the inline-styles of the root element.",
+        "defaultValue": {
+          "value": "{}",
+          "computed": false
+        }
+      },
+      "titleChildren": {
+        "flowType": {
+          "name": "Node"
+        },
+        "required": false,
+        "description": "Can be used to render elements inside the Card Title.",
+        "defaultValue": {
+          "value": "[]",
+          "computed": false
+        }
+      },
+      "titleStyle": {
+        "flowType": {
+          "name": "Object"
+        },
+        "required": false,
+        "description": "Override the inline-styles of the root element.",
+        "defaultValue": {
+          "value": "{}",
+          "computed": false
+        }
+      },
+      "titleSubtitle": {
+        "flowType": {
+          "name": "Node"
+        },
+        "required": false,
+        "description": "Can be used to render a subtitle in the Card Title.",
+        "defaultValue": {
+          "value": "[]",
+          "computed": false
+        }
+      },
+      "titleSubtitleColor": {
+        "flowType": {
+          "name": "string"
+        },
+        "required": false,
+        "description": "Override the subtitle color.",
+        "defaultValue": {
+          "value": "''",
+          "computed": false
+        }
+      },
+      "titleSubtitleStyle": {
+        "flowType": {
+          "name": "Object"
+        },
+        "required": false,
+        "description": "Override the inline-styles of the subtitle.",
+        "defaultValue": {
+          "value": "{}",
+          "computed": false
+        }
+      },
+      "titleTitle": {
+        "flowType": {
+          "name": "Node"
+        },
+        "required": false,
+        "description": "Can be used to render a title in the Card Title.",
+        "defaultValue": {
+          "value": "[]",
+          "computed": false
+        }
+      },
+      "titleColor": {
+        "flowType": {
+          "name": "string"
+        },
+        "required": false,
+        "description": "Override the title color.",
+        "defaultValue": {
+          "value": "''",
+          "computed": false
+        }
+      },
+      "titleTitleStyle": {
+        "flowType": {
+          "name": "Object"
+        },
+        "required": false,
+        "description": "Override the inline-styles of the title.",
+        "defaultValue": {
+          "value": "{}",
+          "computed": false
+        }
+      }
+    }
+  },
   "src/components/Checkbox/Checkbox.react.js": {
     "description": "",
     "displayName": "Checkbox",

--- a/sd_material_ui/metadata.json
+++ b/sd_material_ui/metadata.json
@@ -746,22 +746,7 @@
   "src/components/Card/Card.react.js": {
     "description": "",
     "displayName": "Card",
-    "methods": [
-      {
-        "name": "handleExpandChange",
-        "docblock": null,
-        "modifiers": [],
-        "params": [
-          {
-            "name": "expanded",
-            "type": {
-              "name": "boolean"
-            }
-          }
-        ],
-        "returns": null
-      }
-    ],
+    "methods": [],
     "props": {
       "children": {
         "flowType": {
@@ -800,15 +785,19 @@
         "flowType": {
           "name": "boolean"
         },
-        "required": true,
+        "required": false,
         "description": "If true, this card component is expandable."
       },
       "expanded": {
         "flowType": {
           "name": "boolean"
         },
-        "required": true,
-        "description": "Whether this card is expanded."
+        "required": false,
+        "description": "Whether this card is expanded.\nIf true or false the component is controlled. if null the component is uncontrolled.",
+        "defaultValue": {
+          "value": "null",
+          "computed": false
+        }
       },
       "id": {
         "flowType": {
@@ -828,25 +817,6 @@
           "computed": false
         }
       },
-      "setProps": {
-        "flowType": {
-          "name": "signature",
-          "type": "function",
-          "raw": "() => void",
-          "signature": {
-            "arguments": [],
-            "return": {
-              "name": "void"
-            }
-          }
-        },
-        "required": false,
-        "description": "Dash callback to update props",
-        "defaultValue": {
-          "value": "() => {}",
-          "computed": false
-        }
-      },
       "style": {
         "flowType": {
           "name": "Object"
@@ -855,6 +825,28 @@
         "description": "Override the inline-styles of the root element.",
         "defaultValue": {
           "value": "{}",
+          "computed": false
+        }
+      },
+      "showExpandableButton": {
+        "flowType": {
+          "name": "boolean"
+        },
+        "required": false,
+        "description": "",
+        "defaultValue": {
+          "value": "true",
+          "computed": false
+        }
+      },
+      "headerActAsExpander": {
+        "flowType": {
+          "name": "boolean"
+        },
+        "required": false,
+        "description": "If true, a click on this card component expands the card.",
+        "defaultValue": {
+          "value": "true",
           "computed": false
         }
       },
@@ -979,6 +971,17 @@
           "computed": false
         }
       },
+      "mediaExpandable": {
+        "flowType": {
+          "name": "boolean"
+        },
+        "required": false,
+        "description": "If true, this card component is expandable.",
+        "defaultValue": {
+          "value": "true",
+          "computed": false
+        }
+      },
       "mediaMediaStyle": {
         "flowType": {
           "name": "Object"
@@ -1067,6 +1070,28 @@
           "computed": false
         }
       },
+      "textExpandableBeforeMedia": {
+        "flowType": {
+          "name": "boolean"
+        },
+        "required": false,
+        "description": "If true, this card component is expandable.",
+        "defaultValue": {
+          "value": "true",
+          "computed": false
+        }
+      },
+      "textExpandableAfterMedia": {
+        "flowType": {
+          "name": "boolean"
+        },
+        "required": false,
+        "description": "If true, this card component is expandable.",
+        "defaultValue": {
+          "value": "true",
+          "computed": false
+        }
+      },
       "textStyleBeforeMedia": {
         "flowType": {
           "name": "Object"
@@ -1119,6 +1144,17 @@
         "description": "Can be used to render elements inside the Card Title.",
         "defaultValue": {
           "value": "[]",
+          "computed": false
+        }
+      },
+      "titleExpandable": {
+        "flowType": {
+          "name": "boolean"
+        },
+        "required": false,
+        "description": "If true, this card component is expandable.",
+        "defaultValue": {
+          "value": "true",
           "computed": false
         }
       },

--- a/sd_material_ui/metadata.json
+++ b/sd_material_ui/metadata.json
@@ -799,13 +799,6 @@
           "computed": false
         }
       },
-      "id": {
-        "flowType": {
-          "name": "string"
-        },
-        "required": true,
-        "description": "Component ID"
-      },
       "initiallyExpanded": {
         "flowType": {
           "name": "boolean"
@@ -960,127 +953,6 @@
           "computed": false
         }
       },
-      "mediaChildren": {
-        "flowType": {
-          "name": "Node"
-        },
-        "required": false,
-        "description": "Can be used to render elements inside the Card Media.",
-        "defaultValue": {
-          "value": "[]",
-          "computed": false
-        }
-      },
-      "mediaExpandable": {
-        "flowType": {
-          "name": "boolean"
-        },
-        "required": false,
-        "description": "If true, this card component is expandable.",
-        "defaultValue": {
-          "value": "true",
-          "computed": false
-        }
-      },
-      "mediaMediaStyle": {
-        "flowType": {
-          "name": "Object"
-        },
-        "required": false,
-        "description": "Override the inline-styles of the Card Media.",
-        "defaultValue": {
-          "value": "{}",
-          "computed": false
-        }
-      },
-      "mediaOverlay": {
-        "flowType": {
-          "name": "Node"
-        },
-        "required": false,
-        "description": "Can be used to render overlay element in Card Media.",
-        "defaultValue": {
-          "value": "[]",
-          "computed": false
-        }
-      },
-      "mediaOverlayContainerStyle": {
-        "flowType": {
-          "name": "Object"
-        },
-        "required": false,
-        "description": "Override the inline-styles of the overlay container.",
-        "defaultValue": {
-          "value": "{}",
-          "computed": false
-        }
-      },
-      "mediaContentStyle": {
-        "flowType": {
-          "name": "Object"
-        },
-        "required": false,
-        "description": "Override the inline-styles of the overlay content.",
-        "defaultValue": {
-          "value": "{}",
-          "computed": false
-        }
-      },
-      "mediaOverlayStyle": {
-        "flowType": {
-          "name": "Object"
-        },
-        "required": false,
-        "description": "Override the inline-styles of the overlay element.",
-        "defaultValue": {
-          "value": "{}",
-          "computed": false
-        }
-      },
-      "mediaStyle": {
-        "flowType": {
-          "name": "Object"
-        },
-        "required": false,
-        "description": "Override the inline-styles of the root element.",
-        "defaultValue": {
-          "value": "{}",
-          "computed": false
-        }
-      },
-      "textChildrenBeforeMedia": {
-        "flowType": {
-          "name": "Node"
-        },
-        "required": false,
-        "description": "Can be used to render elements inside the Card Text.",
-        "defaultValue": {
-          "value": "[]",
-          "computed": false
-        }
-      },
-      "textColorBeforeMedia": {
-        "flowType": {
-          "name": "string"
-        },
-        "required": false,
-        "description": "Override the CardText color.",
-        "defaultValue": {
-          "value": "''",
-          "computed": false
-        }
-      },
-      "textExpandableBeforeMedia": {
-        "flowType": {
-          "name": "boolean"
-        },
-        "required": false,
-        "description": "If true, this card component is expandable.",
-        "defaultValue": {
-          "value": "true",
-          "computed": false
-        }
-      },
       "textExpandableAfterMedia": {
         "flowType": {
           "name": "boolean"
@@ -1089,28 +961,6 @@
         "description": "If true, this card component is expandable.",
         "defaultValue": {
           "value": "true",
-          "computed": false
-        }
-      },
-      "textStyleBeforeMedia": {
-        "flowType": {
-          "name": "Object"
-        },
-        "required": false,
-        "description": "Override the inline-styles of the root element.",
-        "defaultValue": {
-          "value": "{}",
-          "computed": false
-        }
-      },
-      "textChildrenAfterMedia": {
-        "flowType": {
-          "name": "Node"
-        },
-        "required": false,
-        "description": "Can be used to render elements inside the Card Text.",
-        "defaultValue": {
-          "value": "[]",
           "computed": false
         }
       },

--- a/sd_material_ui/metadata.json
+++ b/sd_material_ui/metadata.json
@@ -786,14 +786,18 @@
           "name": "boolean"
         },
         "required": false,
-        "description": "If true, this card component is expandable."
+        "description": "If true, this card component is expandable.",
+        "defaultValue": {
+          "value": "false",
+          "computed": false
+        }
       },
-      "expanded": {
+      "_expanded": {
         "flowType": {
           "name": "boolean"
         },
         "required": false,
-        "description": "Whether this card is expanded.\nIf true or false the component is controlled. if null the component is uncontrolled.",
+        "description": "Set to null to keep the component uncontrolled.",
         "defaultValue": {
           "value": "null",
           "computed": false
@@ -826,7 +830,7 @@
           "name": "boolean"
         },
         "required": false,
-        "description": "",
+        "description": "If true, this card component will include a button to expand the card.",
         "defaultValue": {
           "value": "true",
           "computed": false
@@ -850,18 +854,7 @@
         "required": false,
         "description": "This is the Avatar element to be displayed on the Card Header. If avatar is an Avatar or\nother element, it will be rendered. If avatar is a string, it will be used as the image src\nfor an Avatar.",
         "defaultValue": {
-          "value": "[]",
-          "computed": false
-        }
-      },
-      "headerChildren": {
-        "flowType": {
-          "name": "Node"
-        },
-        "required": false,
-        "description": "Can be used to render elements inside the Card Header.",
-        "defaultValue": {
-          "value": "[]",
+          "value": "null",
           "computed": false
         }
       },
@@ -953,50 +946,6 @@
           "computed": false
         }
       },
-      "textExpandableAfterMedia": {
-        "flowType": {
-          "name": "boolean"
-        },
-        "required": false,
-        "description": "If true, this card component is expandable.",
-        "defaultValue": {
-          "value": "true",
-          "computed": false
-        }
-      },
-      "textColorAfterMedia": {
-        "flowType": {
-          "name": "string"
-        },
-        "required": false,
-        "description": "Override the CardText color.",
-        "defaultValue": {
-          "value": "''",
-          "computed": false
-        }
-      },
-      "textStyleAfterMedia": {
-        "flowType": {
-          "name": "Object"
-        },
-        "required": false,
-        "description": "Override the inline-styles of the root element.",
-        "defaultValue": {
-          "value": "{}",
-          "computed": false
-        }
-      },
-      "titleChildren": {
-        "flowType": {
-          "name": "Node"
-        },
-        "required": false,
-        "description": "Can be used to render elements inside the Card Title.",
-        "defaultValue": {
-          "value": "[]",
-          "computed": false
-        }
-      },
       "titleExpandable": {
         "flowType": {
           "name": "boolean"
@@ -1080,6 +1029,39 @@
         },
         "required": false,
         "description": "Override the inline-styles of the title.",
+        "defaultValue": {
+          "value": "{}",
+          "computed": false
+        }
+      },
+      "textExpandable": {
+        "flowType": {
+          "name": "boolean"
+        },
+        "required": false,
+        "description": "If true, this card component is expandable.",
+        "defaultValue": {
+          "value": "true",
+          "computed": false
+        }
+      },
+      "textColor": {
+        "flowType": {
+          "name": "string"
+        },
+        "required": false,
+        "description": "Override the CardText color.",
+        "defaultValue": {
+          "value": "''",
+          "computed": false
+        }
+      },
+      "textStyle": {
+        "flowType": {
+          "name": "Object"
+        },
+        "required": false,
+        "description": "Override the inline-styles of the root element.",
         "defaultValue": {
           "value": "{}",
           "computed": false

--- a/sd_material_ui/version.py
+++ b/sd_material_ui/version.py
@@ -9,4 +9,4 @@ Notes :
 December 28, 2017
 """
 
-__version__ = '2.12.0'
+__version__ = '2.13.0'

--- a/src/components/Card/Card.react.js
+++ b/src/components/Card/Card.react.js
@@ -119,7 +119,7 @@ const defaultProps = {
   headerChildren: [],
   headerStyle: {},
   headerSubtitle: [],
-  headerSubtitlColor: '',
+  headerSubtitleColor: '',
   headerSubtitleStyle: {},
   headerTextStyle: {},
   headerTitle: [],
@@ -193,6 +193,7 @@ export default class Card extends Component<Props, State> {
             expandable={expandable}
             expanded={this.state.expanded}
             initialyExpanded={initiallyExpanded}
+            onExpandChange={this.handleExpandChange}
             style={style}
           >
             {this.props.children}

--- a/src/components/Card/Card.react.js
+++ b/src/components/Card/Card.react.js
@@ -2,7 +2,7 @@
 
 import React, { Component } from 'react';
 
-import { Card as MuiCard, CardHeader, CardMedia, CardTitle, CardText } from 'material-ui/Card';
+import { Card as MuiCard, CardHeader, CardTitle, CardText } from 'material-ui/Card';
 import lightBaseTheme from 'material-ui/styles/baseThemes/lightBaseTheme';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import getMuiTheme from 'material-ui/styles/getMuiTheme';
@@ -21,8 +21,6 @@ type Props = {
    * If true or false the component is controlled. if null the component is uncontrolled.
    */
   expanded?: boolean,
-  /** Component ID */
-  id: string,
   /** Whether this card is initially expanded. */
   initiallyExpanded?: boolean,
   // /** Dash callback to update props */
@@ -60,37 +58,9 @@ type Props = {
   /** Override the inline-styles of the title. */
   headerTitleStyle?: Object,
 
-  // Card media properties
-  /** Can be used to render elements inside the Card Media. */
-  mediaChildren?: Node,
-  /** If true, this card component is expandable. */
-  mediaExpandable?: boolean,
-  /** Override the inline-styles of the Card Media. */
-  mediaMediaStyle?: Object,
-  /** Can be used to render overlay element in Card Media. */
-  mediaOverlay?: Node,
-  /** Override the inline-styles of the overlay container. */
-  mediaOverlayContainerStyle?: Object,
-  /** Override the inline-styles of the overlay content. */
-  mediaContentStyle?: Object,
-  /** Override the inline-styles of the overlay element. */
-  mediaOverlayStyle?: Object,
-  /** Override the inline-styles of the root element. */
-  mediaStyle?: Object,
-
   // Card text properties
-  /** Can be used to render elements inside the Card Text. */
-  textChildrenBeforeMedia?: Node,
-  /** Override the CardText color. */
-  textColorBeforeMedia?: string,
-  /** If true, this card component is expandable. */
-  textExpandableBeforeMedia?: boolean,
   /** If true, this card component is expandable. */
   textExpandableAfterMedia?: boolean,
-  /** Override the inline-styles of the root element. */
-  textStyleBeforeMedia?: Object,
-  /** Can be used to render elements inside the Card Text. */
-  textChildrenAfterMedia?: Node,
   /** Override the CardText color. */
   textColorAfterMedia?: string,
   /** Override the inline-styles of the root element. */
@@ -117,10 +87,6 @@ type Props = {
   titleTitleStyle?: Object,
 }
 
-// type State ={
-//   expanded: boolean,
-// };
-
 const defaultProps = {
   // Card props
   children: [],
@@ -145,23 +111,8 @@ const defaultProps = {
   headerTitleColor: '',
   headerTitleStyle: {},
 
-  // Card media props
-  mediaChildren: [],
-  mediaExpandable: true,
-  mediaMediaStyle: {},
-  mediaOverlay: [],
-  mediaOverlayContainerStyle: {},
-  mediaContentStyle: {},
-  mediaOverlayStyle: {},
-  mediaStyle: {},
-
   // Card text props
-  textChildrenBeforeMedia: [],
-  textColorBeforeMedia: '',
-  textStyleBeforeMedia: {},
-  textExpandableBeforeMedia: true,
   textExpandableAfterMedia: true,
-  textChildrenAfterMedia: [],
   textColorAfterMedia: '',
   textStyleAfterMedia: {},
 
@@ -178,39 +129,17 @@ const defaultProps = {
 };
 
 export default class Card extends Component<Props, State> {
-  // constructor(props: Props) {
-  //   super(props);
-  //   this.state = {expanded: props.expanded};
-  // }
-
-  // componentWillReceiveProps(nextProps: Props): void {
-  //   if (nextProps.expanded !== null && nextProps.expanded !== this.props.expanded) {
-  //     this.handleExpandChange(nextProps.expanded);
-  //   }
-  // }
-  //
-  // handleExpandChange = (expanded: boolean) => {
-  //   const { setProps } = this.props;
-  //
-  //   if (typeof setProps === 'function')
-  //     setProps({expanded});
-  //
-  //   this.setState({expanded});
-  // };
-
   render() {
-    const { className, containerStyle, expandable, id, initiallyExpanded, style, expanded,
+    const { className, containerStyle, expandable, initiallyExpanded, style, expanded,
       showExpandableButton, headerAvatar, headerActAsExpander, headerStyle, headerSubtitle,
       headerSubtitleColor,
       headerSubtitleStyle, headerTextStyle, headerTitle, headerTitleColor, headerTitleStyle,
-      mediaMediaStyle, mediaExpandable, mediaOverlay, mediaOverlayContainerStyle, mediaContentStyle,
-      mediaOverlayStyle, mediaStyle, textExpandableBeforeMedia, textExpandableAfterMedia,
-      textColorBeforeMedia, textStyleBeforeMedia, textColorAfterMedia, textStyleAfterMedia,
+      textExpandableAfterMedia, textColorAfterMedia, textStyleAfterMedia,
       titleStyle, titleSubtitle, titleSubtitleColor, titleSubtitleStyle, titleTitle, titleColor,
       titleTitleStyle, titleExpandable} = this.props;
 
     return (
-      <div id={id}>
+      <div>
         <MuiThemeProvider muiTheme={getMuiTheme(lightBaseTheme)}>
           <MuiCard
             className={className}
@@ -222,7 +151,6 @@ export default class Card extends Component<Props, State> {
             style={style}
             showExpandableButton={showExpandableButton}
           >
-            {this.props.children}
             <CardHeader
               avatar={headerAvatar}
               actAsExpander={headerActAsExpander}
@@ -238,24 +166,6 @@ export default class Card extends Component<Props, State> {
             >
               {this.props.headerChildren}
             </CardHeader>
-            <CardText
-              expandable={textExpandableBeforeMedia}
-              textColor={textColorBeforeMedia}
-              textStyle={textStyleBeforeMedia}
-            >
-              {this.props.textChildrenBeforeMedia}
-            </CardText>
-            <CardMedia
-              mediaStyle={mediaMediaStyle}
-              expandable={mediaExpandable}
-              overlay={mediaOverlay}
-              overlayContainerStyle={mediaOverlayContainerStyle}
-              contentStyle={mediaContentStyle}
-              overlayStyle={mediaOverlayStyle}
-              style={mediaStyle}
-            >
-              {this.props.mediaChildren}
-            </CardMedia>
             <CardTitle
               expandable={titleExpandable}
               style={titleStyle}
@@ -273,7 +183,7 @@ export default class Card extends Component<Props, State> {
               textColor={textColorAfterMedia}
               textStyle={textStyleAfterMedia}
             >
-              {this.props.textChildrenAfterMedia}
+              {this.props.children}
             </CardText>
           </MuiCard>
         </MuiThemeProvider>

--- a/src/components/Card/Card.react.js
+++ b/src/components/Card/Card.react.js
@@ -17,30 +17,22 @@ type Props = {
   containerStyle?: Object,
   /** If true, this card component is expandable. */
   expandable?: boolean,
-  /** Whether this card is expanded.
-   * If true or false the component is controlled. if null the component is uncontrolled.
-   */
-  expanded?: boolean,
+  /** Set to null to keep the component uncontrolled. */
+  _expanded?: boolean,
   /** Whether this card is initially expanded. */
   initiallyExpanded?: boolean,
-  // /** Dash callback to update props */
-  // setProps?: () => void,
   /** Override the inline-styles of the root element. */
   style?: Object,
-  /** */
+  /** If true, this card component will include a button to expand the card. */
   showExpandableButton?: boolean,
 
   // Card header properties
-  /**
-   * If true, a click on this card component expands the card.
-   */
+  /** If true, a click on this card component expands the card. */
   headerActAsExpander?: boolean,
   /** This is the Avatar element to be displayed on the Card Header. If avatar is an Avatar or
    * other element, it will be rendered. If avatar is a string, it will be used as the image src
    * for an Avatar. */
   headerAvatar?: Node,
-  /** Can be used to render elements inside the Card Header. */
-  headerChildren?: Node,
   /** Override the inline-styles of the root element. */
   headerStyle?: Object,
   /** Can be used to render a subtitle in Card Header. */
@@ -58,17 +50,7 @@ type Props = {
   /** Override the inline-styles of the title. */
   headerTitleStyle?: Object,
 
-  // Card text properties
-  /** If true, this card component is expandable. */
-  textExpandableAfterMedia?: boolean,
-  /** Override the CardText color. */
-  textColorAfterMedia?: string,
-  /** Override the inline-styles of the root element. */
-  textStyleAfterMedia?: Object,
-
   // Card title properties
-  /** Can be used to render elements inside the Card Title. */
-  titleChildren?: Node,
   /** If true, this card component is expandable. */
   titleExpandable?: boolean,
   /** Override the inline-styles of the root element. */
@@ -85,6 +67,14 @@ type Props = {
   titleColor?: string,
   /** Override the inline-styles of the title. */
   titleTitleStyle?: Object,
+
+  // Card text properties
+  /** If true, this card component is expandable. */
+  textExpandable?: boolean,
+  /** Override the CardText color. */
+  textColor?: string,
+  /** Override the inline-styles of the root element. */
+  textStyle?: Object,
 }
 
 const defaultProps = {
@@ -92,16 +82,15 @@ const defaultProps = {
   children: [],
   className: '',
   containerStyle: {},
-  expanded: null,
+  expandable: false,
+  _expanded: null,
   initiallyExpanded: false,
-  // setProps: () => {},
   style: {},
   showExpandableButton: true,
 
   // Card header props
-  headerAvatar: [],
+  headerAvatar: null,
   headerActAsExpander: true,
-  headerChildren: [],
   headerStyle: {},
   headerSubtitle: [],
   headerSubtitleColor: '',
@@ -111,13 +100,7 @@ const defaultProps = {
   headerTitleColor: '',
   headerTitleStyle: {},
 
-  // Card text props
-  textExpandableAfterMedia: true,
-  textColorAfterMedia: '',
-  textStyleAfterMedia: {},
-
   // Card title props
-  titleChildren: [],
   titleExpandable: true,
   titleStyle: {},
   titleSubtitle: [],
@@ -126,16 +109,20 @@ const defaultProps = {
   titleTitle: [],
   titleColor: '',
   titleTitleStyle: {},
+
+  // Card text props
+  textExpandable: true,
+  textColor: '',
+  textStyle: {},
 };
 
-export default class Card extends Component<Props, State> {
+export default class Card extends Component<Props> {
   render() {
-    const { className, containerStyle, expandable, initiallyExpanded, style, expanded,
+    const { className, containerStyle, expandable, _expanded, initiallyExpanded, style,
       showExpandableButton, headerAvatar, headerActAsExpander, headerStyle, headerSubtitle,
-      headerSubtitleColor,
-      headerSubtitleStyle, headerTextStyle, headerTitle, headerTitleColor, headerTitleStyle,
-      textExpandableAfterMedia, textColorAfterMedia, textStyleAfterMedia,
-      titleStyle, titleSubtitle, titleSubtitleColor, titleSubtitleStyle, titleTitle, titleColor,
+      headerSubtitleColor, headerSubtitleStyle, headerTextStyle, headerTitle, headerTitleColor,
+      headerTitleStyle, textExpandable, textColor, textStyle, titleStyle, titleSubtitle,
+      titleSubtitleColor, titleSubtitleStyle, titleTitle, titleColor,
       titleTitleStyle, titleExpandable} = this.props;
 
     return (
@@ -145,27 +132,23 @@ export default class Card extends Component<Props, State> {
             className={className}
             containerStyle={containerStyle}
             expandable={expandable}
-            expanded={expanded}
+            expanded={_expanded}
             initialyExpanded={initiallyExpanded}
-            onExpandChange={this.handleExpandChange}
             style={style}
-            showExpandableButton={showExpandableButton}
           >
             <CardHeader
-              avatar={headerAvatar}
               actAsExpander={headerActAsExpander}
+              avatar={headerAvatar}
+              showExpandableButton={showExpandableButton}
               style={headerStyle}
               subtitle={headerSubtitle}
               subtitleColor={headerSubtitleColor}
               subtitleStyle={headerSubtitleStyle}
-              showExpandableButton={showExpandableButton}
               textStyle={headerTextStyle}
               title={headerTitle}
               titleColor={headerTitleColor}
               titleStyle={headerTitleStyle}
-            >
-              {this.props.headerChildren}
-            </CardHeader>
+            />
             <CardTitle
               expandable={titleExpandable}
               style={titleStyle}
@@ -175,13 +158,11 @@ export default class Card extends Component<Props, State> {
               title={titleTitle}
               color={titleColor}
               titleStyle={titleTitleStyle}
-            >
-              {this.props.titleChildren}
-            </CardTitle>
+            />
             <CardText
-              expandable={textExpandableAfterMedia}
-              textColor={textColorAfterMedia}
-              textStyle={textStyleAfterMedia}
+              expandable={textExpandable}
+              textColor={textColor}
+              textStyle={textStyle}
             >
               {this.props.children}
             </CardText>

--- a/src/components/Card/Card.react.js
+++ b/src/components/Card/Card.react.js
@@ -16,19 +16,27 @@ type Props = {
   /** Override the inline-styles of the container element. */
   containerStyle?: Object,
   /** If true, this card component is expandable. */
-  expandable: boolean,
-  /** Whether this card is expanded. */
-  expanded: boolean,
+  expandable?: boolean,
+  /** Whether this card is expanded.
+   * If true or false the component is controlled. if null the component is uncontrolled.
+   */
+  expanded?: boolean,
   /** Component ID */
   id: string,
   /** Whether this card is initially expanded. */
   initiallyExpanded?: boolean,
-  /** Dash callback to update props */
-  setProps?: () => void,
+  // /** Dash callback to update props */
+  // setProps?: () => void,
   /** Override the inline-styles of the root element. */
   style?: Object,
+  /** */
+  showExpandableButton?: boolean,
 
   // Card header properties
+  /**
+   * If true, a click on this card component expands the card.
+   */
+  headerActAsExpander?: boolean,
   /** This is the Avatar element to be displayed on the Card Header. If avatar is an Avatar or
    * other element, it will be rendered. If avatar is a string, it will be used as the image src
    * for an Avatar. */
@@ -55,6 +63,8 @@ type Props = {
   // Card media properties
   /** Can be used to render elements inside the Card Media. */
   mediaChildren?: Node,
+  /** If true, this card component is expandable. */
+  mediaExpandable?: boolean,
   /** Override the inline-styles of the Card Media. */
   mediaMediaStyle?: Object,
   /** Can be used to render overlay element in Card Media. */
@@ -73,6 +83,10 @@ type Props = {
   textChildrenBeforeMedia?: Node,
   /** Override the CardText color. */
   textColorBeforeMedia?: string,
+  /** If true, this card component is expandable. */
+  textExpandableBeforeMedia?: boolean,
+  /** If true, this card component is expandable. */
+  textExpandableAfterMedia?: boolean,
   /** Override the inline-styles of the root element. */
   textStyleBeforeMedia?: Object,
   /** Can be used to render elements inside the Card Text. */
@@ -85,6 +99,8 @@ type Props = {
   // Card title properties
   /** Can be used to render elements inside the Card Title. */
   titleChildren?: Node,
+  /** If true, this card component is expandable. */
+  titleExpandable?: boolean,
   /** Override the inline-styles of the root element. */
   titleStyle?: Object,
   /** Can be used to render a subtitle in the Card Title. */
@@ -101,21 +117,24 @@ type Props = {
   titleTitleStyle?: Object,
 }
 
-type State ={
-  expanded: boolean,
-};
+// type State ={
+//   expanded: boolean,
+// };
 
 const defaultProps = {
   // Card props
   children: [],
   className: '',
   containerStyle: {},
+  expanded: null,
   initiallyExpanded: false,
-  setProps: () => {},
+  // setProps: () => {},
   style: {},
+  showExpandableButton: true,
 
   // Card header props
   headerAvatar: [],
+  headerActAsExpander: true,
   headerChildren: [],
   headerStyle: {},
   headerSubtitle: [],
@@ -128,6 +147,7 @@ const defaultProps = {
 
   // Card media props
   mediaChildren: [],
+  mediaExpandable: true,
   mediaMediaStyle: {},
   mediaOverlay: [],
   mediaOverlayContainerStyle: {},
@@ -139,12 +159,15 @@ const defaultProps = {
   textChildrenBeforeMedia: [],
   textColorBeforeMedia: '',
   textStyleBeforeMedia: {},
+  textExpandableBeforeMedia: true,
+  textExpandableAfterMedia: true,
   textChildrenAfterMedia: [],
   textColorAfterMedia: '',
   textStyleAfterMedia: {},
 
   // Card title props
   titleChildren: [],
+  titleExpandable: true,
   titleStyle: {},
   titleSubtitle: [],
   titleSubtitleColor: '',
@@ -155,34 +178,36 @@ const defaultProps = {
 };
 
 export default class Card extends Component<Props, State> {
-  constructor(props: Props) {
-    super(props);
-    this.state = {expanded: props.expanded};
-  }
+  // constructor(props: Props) {
+  //   super(props);
+  //   this.state = {expanded: props.expanded};
+  // }
 
-  componentWillReceiveProps(nextProps: Props): void {
-    if (nextProps.expanded !== null && nextProps.expanded !== this.props.expanded) {
-      this.handleExpandChange(nextProps.expanded);
-    }
-  }
-
-  handleExpandChange = (expanded: boolean) => {
-    const { setProps } = this.props;
-
-    if (typeof setProps === 'function')
-      setProps({expanded});
-
-    this.setState({expanded});
-  };
+  // componentWillReceiveProps(nextProps: Props): void {
+  //   if (nextProps.expanded !== null && nextProps.expanded !== this.props.expanded) {
+  //     this.handleExpandChange(nextProps.expanded);
+  //   }
+  // }
+  //
+  // handleExpandChange = (expanded: boolean) => {
+  //   const { setProps } = this.props;
+  //
+  //   if (typeof setProps === 'function')
+  //     setProps({expanded});
+  //
+  //   this.setState({expanded});
+  // };
 
   render() {
-    const { className, containerStyle, expandable, id, initiallyExpanded, style,
-      headerAvatar, headerStyle, headerSubtitle, headerSubtitleColor, headerSubtitleStyle,
-      headerTextStyle, headerTitle, headerTitleColor, headerTitleStyle, mediaMediaStyle,
-      mediaOverlay, mediaOverlayContainerStyle, mediaContentStyle, mediaOverlayStyle, mediaStyle,
+    const { className, containerStyle, expandable, id, initiallyExpanded, style, expanded,
+      showExpandableButton, headerAvatar, headerActAsExpander, headerStyle, headerSubtitle,
+      headerSubtitleColor,
+      headerSubtitleStyle, headerTextStyle, headerTitle, headerTitleColor, headerTitleStyle,
+      mediaMediaStyle, mediaExpandable, mediaOverlay, mediaOverlayContainerStyle, mediaContentStyle,
+      mediaOverlayStyle, mediaStyle, textExpandableBeforeMedia, textExpandableAfterMedia,
       textColorBeforeMedia, textStyleBeforeMedia, textColorAfterMedia, textStyleAfterMedia,
       titleStyle, titleSubtitle, titleSubtitleColor, titleSubtitleStyle, titleTitle, titleColor,
-      titleTitleStyle} = this.props;
+      titleTitleStyle, titleExpandable} = this.props;
 
     return (
       <div id={id}>
@@ -191,18 +216,21 @@ export default class Card extends Component<Props, State> {
             className={className}
             containerStyle={containerStyle}
             expandable={expandable}
-            expanded={this.state.expanded}
+            expanded={expanded}
             initialyExpanded={initiallyExpanded}
             onExpandChange={this.handleExpandChange}
             style={style}
+            showExpandableButton={showExpandableButton}
           >
             {this.props.children}
             <CardHeader
               avatar={headerAvatar}
+              actAsExpander={headerActAsExpander}
               style={headerStyle}
               subtitle={headerSubtitle}
               subtitleColor={headerSubtitleColor}
               subtitleStyle={headerSubtitleStyle}
+              showExpandableButton={showExpandableButton}
               textStyle={headerTextStyle}
               title={headerTitle}
               titleColor={headerTitleColor}
@@ -211,6 +239,7 @@ export default class Card extends Component<Props, State> {
               {this.props.headerChildren}
             </CardHeader>
             <CardText
+              expandable={textExpandableBeforeMedia}
               textColor={textColorBeforeMedia}
               textStyle={textStyleBeforeMedia}
             >
@@ -218,6 +247,7 @@ export default class Card extends Component<Props, State> {
             </CardText>
             <CardMedia
               mediaStyle={mediaMediaStyle}
+              expandable={mediaExpandable}
               overlay={mediaOverlay}
               overlayContainerStyle={mediaOverlayContainerStyle}
               contentStyle={mediaContentStyle}
@@ -227,6 +257,7 @@ export default class Card extends Component<Props, State> {
               {this.props.mediaChildren}
             </CardMedia>
             <CardTitle
+              expandable={titleExpandable}
               style={titleStyle}
               subtitle={titleSubtitle}
               subtitleColor={titleSubtitleColor}
@@ -238,6 +269,7 @@ export default class Card extends Component<Props, State> {
               {this.props.titleChildren}
             </CardTitle>
             <CardText
+              expandable={textExpandableAfterMedia}
               textColor={textColorAfterMedia}
               textStyle={textStyleAfterMedia}
             >

--- a/src/components/Card/Card.react.js
+++ b/src/components/Card/Card.react.js
@@ -2,7 +2,7 @@
 
 import React, { Component } from 'react';
 
-import MuiCard from 'material-ui/Card';
+import { Card as MuiCard, CardHeader, CardMedia, CardTitle, CardText } from 'material-ui/Card';
 import lightBaseTheme from 'material-ui/styles/baseThemes/lightBaseTheme';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import getMuiTheme from 'material-ui/styles/getMuiTheme';
@@ -19,8 +19,6 @@ type Props = {
   expandable: boolean,
   /** Whether this card is expanded. */
   expanded: boolean,
-  /** Dash event handler for click events */
-  fireEvent?: () => void,
   /** Component ID */
   id: string,
   /** Whether this card is initially expanded. */
@@ -72,11 +70,17 @@ type Props = {
 
   // Card text properties
   /** Can be used to render elements inside the Card Text. */
-  textChildren?: Node,
+  textChildrenBeforeMedia?: Node,
   /** Override the CardText color. */
-  textColor?: string,
+  textColorBeforeMedia?: string,
   /** Override the inline-styles of the root element. */
-  textStyle?: Object,
+  textStyleBeforeMedia?: Object,
+  /** Can be used to render elements inside the Card Text. */
+  textChildrenAfterMedia?: Node,
+  /** Override the CardText color. */
+  textColorAfterMedia?: string,
+  /** Override the inline-styles of the root element. */
+  textStyleAfterMedia?: Object,
 
   // Card title properties
   /** Can be used to render elements inside the Card Title. */
@@ -98,7 +102,7 @@ type Props = {
 }
 
 type State ={
-  open: boolean,
+  expanded: boolean,
 };
 
 const defaultProps = {
@@ -106,7 +110,6 @@ const defaultProps = {
   children: [],
   className: '',
   containerStyle: {},
-  fireEvent: () => {},
   initiallyExpanded: false,
   setProps: () => {},
   style: {},
@@ -133,9 +136,12 @@ const defaultProps = {
   mediaStyle: {},
 
   // Card text props
-  textChildren: [],
-  textColor: '',
-  textStyle: {},
+  textChildrenBeforeMedia: [],
+  textColorBeforeMedia: '',
+  textStyleBeforeMedia: {},
+  textChildrenAfterMedia: [],
+  textColorAfterMedia: '',
+  textStyleAfterMedia: {},
 
   // Card title props
   titleChildren: [],
@@ -148,3 +154,99 @@ const defaultProps = {
   titleTitleStyle: {},
 };
 
+export default class Card extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = {expanded: props.expanded};
+  }
+
+  componentWillReceiveProps(nextProps: Props): void {
+    if (nextProps.expanded !== null && nextProps.expanded !== this.props.expanded) {
+      this.handleExpandChange(nextProps.expanded);
+    }
+  }
+
+  handleExpandChange = (expanded: boolean) => {
+    const { setProps } = this.props;
+
+    if (typeof setProps === 'function')
+      setProps({expanded});
+
+    this.setState({expanded});
+  };
+
+  render() {
+    const { className, containerStyle, expandable, id, initiallyExpanded, style,
+      headerAvatar, headerStyle, headerSubtitle, headerSubtitleColor, headerSubtitleStyle,
+      headerTextStyle, headerTitle, headerTitleColor, headerTitleStyle, mediaMediaStyle,
+      mediaOverlay, mediaOverlayContainerStyle, mediaContentStyle, mediaOverlayStyle, mediaStyle,
+      textColorBeforeMedia, textStyleBeforeMedia, textColorAfterMedia, textStyleAfterMedia,
+      titleStyle, titleSubtitle, titleSubtitleColor, titleSubtitleStyle, titleTitle, titleColor,
+      titleTitleStyle} = this.props;
+
+    return (
+      <div id={id}>
+        <MuiThemeProvider muiTheme={getMuiTheme(lightBaseTheme)}>
+          <MuiCard
+            className={className}
+            containerStyle={containerStyle}
+            expandable={expandable}
+            expanded={this.state.expanded}
+            initialyExpanded={initiallyExpanded}
+            style={style}
+          >
+            {this.props.children}
+            <CardHeader
+              avatar={headerAvatar}
+              style={headerStyle}
+              subtitle={headerSubtitle}
+              subtitleColor={headerSubtitleColor}
+              subtitleStyle={headerSubtitleStyle}
+              textStyle={headerTextStyle}
+              title={headerTitle}
+              titleColor={headerTitleColor}
+              titleStyle={headerTitleStyle}
+            >
+              {this.props.headerChildren}
+            </CardHeader>
+            <CardText
+              textColor={textColorBeforeMedia}
+              textStyle={textStyleBeforeMedia}
+            >
+              {this.props.textChildrenBeforeMedia}
+            </CardText>
+            <CardMedia
+              mediaStyle={mediaMediaStyle}
+              overlay={mediaOverlay}
+              overlayContainerStyle={mediaOverlayContainerStyle}
+              contentStyle={mediaContentStyle}
+              overlayStyle={mediaOverlayStyle}
+              style={mediaStyle}
+            >
+              {this.props.mediaChildren}
+            </CardMedia>
+            <CardTitle
+              style={titleStyle}
+              subtitle={titleSubtitle}
+              subtitleColor={titleSubtitleColor}
+              subtitleStyle={titleSubtitleStyle}
+              title={titleTitle}
+              color={titleColor}
+              titleStyle={titleTitleStyle}
+            >
+              {this.props.titleChildren}
+            </CardTitle>
+            <CardText
+              textColor={textColorAfterMedia}
+              textStyle={textStyleAfterMedia}
+            >
+              {this.props.textChildrenAfterMedia}
+            </CardText>
+          </MuiCard>
+        </MuiThemeProvider>
+      </div>
+    );
+  }
+}
+
+Card.defaultProps = defaultProps;

--- a/src/components/Card/Card.react.js
+++ b/src/components/Card/Card.react.js
@@ -1,0 +1,150 @@
+// @flow
+
+import React, { Component } from 'react';
+
+import MuiCard from 'material-ui/Card';
+import lightBaseTheme from 'material-ui/styles/baseThemes/lightBaseTheme';
+import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
+import getMuiTheme from 'material-ui/styles/getMuiTheme';
+
+type Props = {
+  // Card properties
+  /** Can be used to render elements inside the Card. */
+  children?: Node,
+  /** The CSS class name of the root element */
+  className?: string,
+  /** Override the inline-styles of the container element. */
+  containerStyle?: Object,
+  /** If true, this card component is expandable. */
+  expandable: boolean,
+  /** Whether this card is expanded. */
+  expanded: boolean,
+  /** Dash event handler for click events */
+  fireEvent?: () => void,
+  /** Component ID */
+  id: string,
+  /** Whether this card is initially expanded. */
+  initiallyExpanded?: boolean,
+  /** Dash callback to update props */
+  setProps?: () => void,
+  /** Override the inline-styles of the root element. */
+  style?: Object,
+
+  // Card header properties
+  /** This is the Avatar element to be displayed on the Card Header. If avatar is an Avatar or
+   * other element, it will be rendered. If avatar is a string, it will be used as the image src
+   * for an Avatar. */
+  headerAvatar?: Node,
+  /** Can be used to render elements inside the Card Header. */
+  headerChildren?: Node,
+  /** Override the inline-styles of the root element. */
+  headerStyle?: Object,
+  /** Can be used to render a subtitle in Card Header. */
+  headerSubtitle?: Node,
+  /** Override the subtitle color. */
+  headerSubtitleColor?: string,
+  /** Override the inline-styles of the subtitle. */
+  headerSubtitleStyle?: Object,
+  /** Override the inline-styles of the text. */
+  headerTextStyle?: Object,
+  /** Can be used to render a title in Card Header. */
+  headerTitle?: Node,
+  /** Override the title color. */
+  headerTitleColor?: string,
+  /** Override the inline-styles of the title. */
+  headerTitleStyle?: Object,
+
+  // Card media properties
+  /** Can be used to render elements inside the Card Media. */
+  mediaChildren?: Node,
+  /** Override the inline-styles of the Card Media. */
+  mediaMediaStyle?: Object,
+  /** Can be used to render overlay element in Card Media. */
+  mediaOverlay?: Node,
+  /** Override the inline-styles of the overlay container. */
+  mediaOverlayContainerStyle?: Object,
+  /** Override the inline-styles of the overlay content. */
+  mediaContentStyle?: Object,
+  /** Override the inline-styles of the overlay element. */
+  mediaOverlayStyle?: Object,
+  /** Override the inline-styles of the root element. */
+  mediaStyle?: Object,
+
+  // Card text properties
+  /** Can be used to render elements inside the Card Text. */
+  textChildren?: Node,
+  /** Override the CardText color. */
+  textColor?: string,
+  /** Override the inline-styles of the root element. */
+  textStyle?: Object,
+
+  // Card title properties
+  /** Can be used to render elements inside the Card Title. */
+  titleChildren?: Node,
+  /** Override the inline-styles of the root element. */
+  titleStyle?: Object,
+  /** Can be used to render a subtitle in the Card Title. */
+  titleSubtitle?: Node,
+  /** Override the subtitle color. */
+  titleSubtitleColor?: string,
+  /** Override the inline-styles of the subtitle. */
+  titleSubtitleStyle?: Object,
+  /** Can be used to render a title in the Card Title. */
+  titleTitle?: Node,
+  /** Override the title color. */
+  titleColor?: string,
+  /** Override the inline-styles of the title. */
+  titleTitleStyle?: Object,
+}
+
+type State ={
+  open: boolean,
+};
+
+const defaultProps = {
+  // Card props
+  children: [],
+  className: '',
+  containerStyle: {},
+  fireEvent: () => {},
+  initiallyExpanded: false,
+  setProps: () => {},
+  style: {},
+
+  // Card header props
+  headerAvatar: [],
+  headerChildren: [],
+  headerStyle: {},
+  headerSubtitle: [],
+  headerSubtitlColor: '',
+  headerSubtitleStyle: {},
+  headerTextStyle: {},
+  headerTitle: [],
+  headerTitleColor: '',
+  headerTitleStyle: {},
+
+  // Card media props
+  mediaChildren: [],
+  mediaMediaStyle: {},
+  mediaOverlay: [],
+  mediaOverlayContainerStyle: {},
+  mediaContentStyle: {},
+  mediaOverlayStyle: {},
+  mediaStyle: {},
+
+  // Card text props
+  textChildren: [],
+  textColor: '',
+  textStyle: {},
+
+  // Card title props
+  titleChildren: [],
+  titleStyle: {},
+  titleSubtitle: [],
+  titleSubtitleColor: '',
+  titleSubtitleStyle: {},
+  titleTitle: [],
+  titleColor: '',
+  titleTitleStyle: {},
+};
+

--- a/src/components/Card/index.js
+++ b/src/components/Card/index.js
@@ -1,0 +1,3 @@
+import Card from './Card.react';
+
+export default Card;

--- a/src/components/__tests__/Card.test.js
+++ b/src/components/__tests__/Card.test.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { Card as MuiCard} from 'material-ui/Card';
+import Card from '../Card/Card.react';
+
+describe('Card', () => {
+  it('renders', () => {
+    const component = shallow(
+      <Card />);
+
+    expect(component.find(MuiCard).length).toBe(1);
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import AutoComplete from './components/AutoComplete';
 import BottomNavigation from './components/BottomNavigation';
+import Card from './components/Card';
 import Checkbox from './components/Checkbox';
 import CircularProgress from './components/CircularProgress';
 import Dialog from './components/Dialog';
@@ -19,6 +20,7 @@ import Toggle from './components/Toggle';
 export {
   AutoComplete,
   BottomNavigation,
+  Card,
   Checkbox,
   CircularProgress,
   Dialog,

--- a/usage.py
+++ b/usage.py
@@ -288,10 +288,10 @@ app.layout = html.Div([
         children=[
             sd_material_ui.Card(
                 initiallyExpanded=False,
-                headerTitle='Test card header',
-                headerSubtitle='Test subtitle',
+                headerTitle='Inner card header',
+                headerSubtitle='Inner subtitle',
                 titleExpandable=True,
-                titleTitle='Card content header',
+                titleTitle='Inner card',
                 textExpandableAfterMedia=True,
                 children=[
                     html.P('YAY')

--- a/usage.py
+++ b/usage.py
@@ -279,24 +279,22 @@ app.layout = html.Div([
     spacer,
 
     sd_material_ui.Card(
-        id='output12',
         initiallyExpanded=False,
         headerTitle='Test card header',
         headerSubtitle='Test subtitle',
         titleExpandable=True,
         titleTitle='Card content header',
         textExpandableAfterMedia=True,
-        textChildrenAfterMedia=[
+        children=[
             sd_material_ui.Card(
-                id='output12-a',
                 initiallyExpanded=False,
                 headerTitle='Test card header',
                 headerSubtitle='Test subtitle',
                 titleExpandable=True,
                 titleTitle='Card content header',
                 textExpandableAfterMedia=True,
-                textChildrenAfterMedia=[
-                    'Content goes in here!'
+                children=[
+                    html.P('YAY')
                 ]
             ),
         ]

--- a/usage.py
+++ b/usage.py
@@ -276,6 +276,21 @@ app.layout = html.Div([
     ], style=dict(backgroundColor='#1D3153')),
     html.Div(id='output11', children=['Selected item appears here.']),
 
+    spacer,
+
+    sd_material_ui.Card(
+        id='output12',
+        expandable=True,
+        expanded=False,
+        initiallyExpanded=False,
+        headerTitle='Test card header',
+        headerSubtitle='Test subtitle',
+        titleTitle='Card content header',
+        textChildrenAfterMedia=[
+            'Content goes in here!'
+        ]
+    ),
+
     final_spacer,
 ])
 @app.callback(

--- a/usage.py
+++ b/usage.py
@@ -284,7 +284,7 @@ app.layout = html.Div([
         headerSubtitle='Test subtitle',
         titleExpandable=True,
         titleTitle='Card content header',
-        textExpandableAfterMedia=True,
+        textExpandable=True,
         children=[
             sd_material_ui.Card(
                 initiallyExpanded=False,
@@ -292,7 +292,7 @@ app.layout = html.Div([
                 headerSubtitle='Inner subtitle',
                 titleExpandable=True,
                 titleTitle='Inner card',
-                textExpandableAfterMedia=True,
+                textExpandable=True,
                 children=[
                     html.P('YAY')
                 ]

--- a/usage.py
+++ b/usage.py
@@ -280,14 +280,25 @@ app.layout = html.Div([
 
     sd_material_ui.Card(
         id='output12',
-        expandable=True,
-        expanded=False,
         initiallyExpanded=False,
         headerTitle='Test card header',
         headerSubtitle='Test subtitle',
+        titleExpandable=True,
         titleTitle='Card content header',
+        textExpandableAfterMedia=True,
         textChildrenAfterMedia=[
-            'Content goes in here!'
+            sd_material_ui.Card(
+                id='output12-a',
+                initiallyExpanded=False,
+                headerTitle='Test card header',
+                headerSubtitle='Test subtitle',
+                titleExpandable=True,
+                titleTitle='Card content header',
+                textExpandableAfterMedia=True,
+                textChildrenAfterMedia=[
+                    'Content goes in here!'
+                ]
+            ),
         ]
     ),
 


### PR DESCRIPTION
## Description
Adds a Card component, uncontrolled, which opens and closes, and allows the nesting of other card components inside.

## How has this been tested
Simple JS test runs and passes. Manual test in `usage.py` shows proper function of the component

## Screenshots

![card](https://user-images.githubusercontent.com/16080662/40199089-6e158176-59e6-11e8-9302-74eb3e51efe6.gif)
