### PR TITLE
73 card prop names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.13.1 - 2018-05-18
+### Fixes
+- Updates prop names internally in `CardText` for `style` and `color` to allow `textColor` and `textStyle` props to actually change `CardText` subcomponent
+
+### Added
+- Adds `id` and `headerIconStyle` props to `CardComponent`:
+  - `id` as a `string` to allow for callbacks assigned to the card
+  - `headerIconStyle` to allow for styling the icon in the `CardHeader` subcomponent
+
 ## 2.13.0 - 2018-05-17
 ### Added
 - Adds uncontrolled Card component

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sd-material-ui",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sd-material-ui",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "description": "StratoDem Analytics Dash implementation of material-ui components",
   "main": "lib/index.js",
   "repository": {

--- a/sd_material_ui/metadata.json
+++ b/sd_material_ui/metadata.json
@@ -748,6 +748,17 @@
     "displayName": "Card",
     "methods": [],
     "props": {
+      "id": {
+        "flowType": {
+          "name": "string"
+        },
+        "required": false,
+        "description": "ID for Card",
+        "defaultValue": {
+          "value": "''",
+          "computed": false
+        }
+      },
       "children": {
         "flowType": {
           "name": "Node"
@@ -941,6 +952,17 @@
         },
         "required": false,
         "description": "Override the inline-styles of the title.",
+        "defaultValue": {
+          "value": "{}",
+          "computed": false
+        }
+      },
+      "headerIconStyle": {
+        "flowType": {
+          "name": "Object"
+        },
+        "required": false,
+        "description": "",
         "defaultValue": {
           "value": "{}",
           "computed": false

--- a/sd_material_ui/version.py
+++ b/sd_material_ui/version.py
@@ -9,4 +9,4 @@ Notes :
 December 28, 2017
 """
 
-__version__ = '2.13.0'
+__version__ = '2.13.1'

--- a/src/components/Card/Card.react.js
+++ b/src/components/Card/Card.react.js
@@ -9,6 +9,8 @@ import getMuiTheme from 'material-ui/styles/getMuiTheme';
 
 type Props = {
   // Card properties
+  /** ID for Card */
+  id?: string,
   /** Can be used to render elements inside the Card. */
   children?: Node,
   /** The CSS class name of the root element */
@@ -49,6 +51,8 @@ type Props = {
   headerTitleColor?: string,
   /** Override the inline-styles of the title. */
   headerTitleStyle?: Object,
+  /* Override the iconStyle of the Icon Button. */
+  headerIconStyle?: Object,
 
   // Card title properties
   /** If true, this card component is expandable. */
@@ -79,6 +83,7 @@ type Props = {
 
 const defaultProps = {
   // Card props
+  id: '',
   children: [],
   className: '',
   containerStyle: {},
@@ -99,6 +104,7 @@ const defaultProps = {
   headerTitle: [],
   headerTitleColor: '',
   headerTitleStyle: {},
+  headerIconStyle: {},
 
   // Card title props
   titleExpandable: true,
@@ -118,15 +124,15 @@ const defaultProps = {
 
 export default class Card extends Component<Props> {
   render() {
-    const { className, containerStyle, expandable, _expanded, initiallyExpanded, style,
+    const { id, className, containerStyle, expandable, _expanded, initiallyExpanded, style,
       showExpandableButton, headerAvatar, headerActAsExpander, headerStyle, headerSubtitle,
       headerSubtitleColor, headerSubtitleStyle, headerTextStyle, headerTitle, headerTitleColor,
       headerTitleStyle, textExpandable, textColor, textStyle, titleStyle, titleSubtitle,
-      titleSubtitleColor, titleSubtitleStyle, titleTitle, titleColor,
+      headerIconStyle, titleSubtitleColor, titleSubtitleStyle, titleTitle, titleColor,
       titleTitleStyle, titleExpandable} = this.props;
 
     return (
-      <div>
+      <div id={id}>
         <MuiThemeProvider muiTheme={getMuiTheme(lightBaseTheme)}>
           <MuiCard
             className={className}
@@ -148,6 +154,7 @@ export default class Card extends Component<Props> {
               title={headerTitle}
               titleColor={headerTitleColor}
               titleStyle={headerTitleStyle}
+              iconStyle={headerIconStyle}
             />
             <CardTitle
               expandable={titleExpandable}
@@ -161,8 +168,8 @@ export default class Card extends Component<Props> {
             />
             <CardText
               expandable={textExpandable}
-              textColor={textColor}
-              textStyle={textStyle}
+              color={textColor}
+              style={textStyle}
             >
               {this.props.children}
             </CardText>


### PR DESCRIPTION
### Fixes
- Updates prop names internally in `CardText` for `style` and `color` to allow `textColor` and `textStyle` props to actually change `CardText` subcomponent

### Added
- Adds `id` and `headerIconStyle` props to `CardComponent`:
  - `id` as a `string` to allow for callbacks assigned to the card
  - `headerIconStyle` to allow for styling the icon in the `CardHeader` subcomponent

Closes #73 