### PR TITLE
79 fix checkbox callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.16.1 - 2018-09-05
+### Fixes
+- Fixes https://github.com/StratoDem/sd-material-ui/issues/79 where `Checkbox` callback was firing twice to the server on a click event
+
 ## 2.16.0 - 2018-08-30
 ### Added
 - Adds `Popover` as an uncontrolled component which can render other components as children

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sd-material-ui",
-  "version": "2.15.0",
+  "version": "2.16.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sd-material-ui",
-  "version": "2.16.0",
+  "version": "2.16.1",
   "description": "StratoDem Analytics Dash implementation of material-ui components",
   "main": "lib/index.js",
   "repository": {

--- a/sd_material_ui/metadata.json
+++ b/sd_material_ui/metadata.json
@@ -5246,7 +5246,7 @@
         "flowType": {
           "name": "Object"
         },
-        "required": true,
+        "required": false,
         "description": "Tabs props",
         "defaultValue": {
           "value": "{}",

--- a/sd_material_ui/version.py
+++ b/sd_material_ui/version.py
@@ -9,4 +9,4 @@ Notes :
 December 28, 2017
 """
 
-__version__ = '2.16.0'
+__version__ = '2.16.1'

--- a/src/components/Checkbox/Checkbox.react.js
+++ b/src/components/Checkbox/Checkbox.react.js
@@ -57,7 +57,7 @@ export default class Checkbox extends Component<Props, State> {
 
   componentWillReceiveProps(nextProps: Props): void {
     if (nextProps.checked !== null && nextProps.checked !== this.props.checked)
-      this.handleClick(nextProps.checked);
+      this.setState({checked: nextProps.checked});
   }
 
   handleClick = (checked: boolean) => {
@@ -68,7 +68,8 @@ export default class Checkbox extends Component<Props, State> {
 
     this.setState({checked});
 
-    if (this.props.fireEvent) this.props.fireEvent({event: 'click'});
+    if (this.props.fireEvent)
+      this.props.fireEvent({event: 'click'});
   };
 
   render() {


### PR DESCRIPTION
Updates the `Checkbox` component to fix bug where callback was firing twice on a click event (#79). 

Closes #79
